### PR TITLE
ci: add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint --max-warnings 20
+
+      - name: Build
+        run: pnpm build
+
+      - name: Unit tests
+        run: pnpm test
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: pnpm test:e2e --project=chromium
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7


### PR DESCRIPTION
## What

Adds a CI pipeline via GitHub Actions that runs on every push to `main` and on PRs targeting `main`.

## Pipeline steps

1. **Typecheck** — `pnpm typecheck` (strict TypeScript, no `any`)
2. **Lint** — `pnpm lint` (0 errors allowed, ≤20 warnings)
3. **Build** — `pnpm build` (Next.js production build)
4. **Unit tests** — `pnpm test` (Vitest, 96 tests)
5. **E2E tests** — `pnpm test:e2e --project=chromium` (Playwright, 58 tests)

Uploads Playwright HTML report as artifact on failure.

## Local verification

All checks pass locally:
- Build: ✅
- Typecheck: ✅  
- Lint: 0 errors (13 warnings)
- Unit tests: 96/96 ✅
- E2E: 58/58 ✅