### PR TITLE
feat: fase 2 — organizations page

### DIFF
--- a/src/app/(dashboard)/orgs/page.tsx
+++ b/src/app/(dashboard)/orgs/page.tsx
@@ -1,17 +1,222 @@
-import { MnBadge } from '@/components/maranello';
+'use client';
 
-export const metadata = { title: 'Organizations — Convergio' };
+import { useCallback, useMemo, useState } from 'react';
+import { useApiQuery } from '@/hooks/use-api-query';
+import * as api from '@/lib/api';
+import type { Org, OrgInput, PeerEntry } from '@/lib/types';
+import { MnSectionCard } from '@/components/maranello/layout';
+import { MnDataTable, type DataTableColumn, MnBadge } from '@/components/maranello/data-display';
+import { MnOrgChart, type OrgNode } from '@/components/maranello/network';
+import { MnBudgetTreemap, type TreemapItem } from '@/components/maranello/data-viz';
+import { MnModal } from '@/components/maranello/feedback';
+import { MnFormField } from '@/components/maranello/forms';
+import { MnProgressRing } from '@/components/maranello/data-display';
+import { MnStateScaffold } from '@/components/maranello/feedback';
+
+const ORG_COLUMNS: DataTableColumn[] = [
+  { key: 'name', label: 'Name', sortable: true },
+  { key: 'status', label: 'Status', type: 'status' },
+  { key: 'agent_count', label: 'Agents', sortable: true },
+  { key: 'budget_usd', label: 'Budget ($)', sortable: true },
+  { key: 'spent_usd', label: 'Spent ($)', sortable: true },
+  { key: 'created_at', label: 'Created', sortable: true },
+];
 
 export default function OrgsPage() {
+  const [selectedOrg, setSelectedOrg] = useState<Org | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [formData, setFormData] = useState<OrgInput>({ name: '', budget_usd: 0 });
+  const [saving, setSaving] = useState(false);
+
+  const { data: orgs, loading, error, refetch } = useApiQuery<Org[]>(api.orgList);
+  const { data: peers } = useApiQuery<PeerEntry[]>(
+    () => selectedOrg ? api.tenancyPeers(selectedOrg.id) : Promise.resolve([]),
+    { enabled: !!selectedOrg },
+  );
+
+  const orgTree: OrgNode = useMemo(() => ({
+    name: 'Convergio Platform',
+    role: 'Root',
+    status: 'active',
+    children: (orgs ?? []).map((o) => ({
+      name: o.name,
+      role: o.description ?? 'Organization',
+      status: o.status === 'active' ? 'active' : o.status === 'suspended' ? 'error' : 'inactive' as const,
+    })),
+  }), [orgs]);
+
+  const budgetItems: TreemapItem[] = useMemo(
+    () => (orgs ?? []).map((o) => ({ name: o.name, value: o.spent_usd })),
+    [orgs],
+  );
+
+  const handleCreate = useCallback(async () => {
+    if (!formData.name) return;
+    setSaving(true);
+    try {
+      await api.orgCreate(formData);
+      setShowCreate(false);
+      setFormData({ name: '', budget_usd: 0 });
+      refetch();
+    } finally {
+      setSaving(false);
+    }
+  }, [formData, refetch]);
+
+  const handleDelete = useCallback(async (org: Org) => {
+    if (!confirm(`Delete organization "${org.name}"?`)) return;
+    await api.orgDelete(org.id);
+    setSelectedOrg(null);
+    refetch();
+  }, [refetch]);
+
+  if (loading) return <MnStateScaffold state="loading" message="Loading organizations..." />;
+  if (error) return <MnStateScaffold state="error" message={error} onRetry={refetch} />;
+
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
+      <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Organizations</h1>
-        <MnBadge tone="info">Coming in Fase 2</MnBadge>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          New Organization
+        </button>
       </div>
-      <p className="text-muted-foreground">
-        Org CRUD, orgchart, inter-org delegation, budget management.
-      </p>
+
+      <MnSectionCard title="All Organizations" badge={(orgs ?? []).length} collapsible defaultOpen>
+        <MnDataTable
+          columns={ORG_COLUMNS}
+          data={(orgs ?? []) as unknown as Record<string, unknown>[]}
+          onRowClick={(row) => setSelectedOrg(row as unknown as Org)}
+          emptyMessage="No organizations found"
+        />
+      </MnSectionCard>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <MnSectionCard title="Org Chart" collapsible defaultOpen>
+          <div className="p-4">
+            <MnOrgChart
+              tree={orgTree}
+              onNodeClick={(node) => {
+                const found = (orgs ?? []).find((o) => o.name === node.name);
+                if (found) setSelectedOrg(found);
+              }}
+              ariaLabel="Organization hierarchy"
+            />
+          </div>
+        </MnSectionCard>
+
+        <MnSectionCard title="Budget Distribution" collapsible defaultOpen>
+          <div className="p-4">
+            {budgetItems.length > 0 ? (
+              <MnBudgetTreemap items={budgetItems} ariaLabel="Budget by organization" />
+            ) : (
+              <p className="text-sm text-muted-foreground">No budget data</p>
+            )}
+          </div>
+        </MnSectionCard>
+
+        {selectedOrg && (
+          <MnSectionCard
+            title={selectedOrg.name}
+            collapsible
+            defaultOpen
+            action={{ label: 'Delete', onClick: () => handleDelete(selectedOrg) }}
+          >
+            <div className="space-y-4 p-4">
+              <div className="flex items-center gap-3">
+                <MnBadge tone={selectedOrg.status === 'active' ? 'success' : 'danger'}>
+                  {selectedOrg.status}
+                </MnBadge>
+                <span className="text-sm text-muted-foreground">{selectedOrg.description}</span>
+              </div>
+              <div className="flex items-center gap-6">
+                <MnProgressRing
+                  value={selectedOrg.spent_usd}
+                  max={selectedOrg.budget_usd}
+                  size="md"
+                  label="Budget usage"
+                />
+                <div>
+                  <p className="text-sm font-medium">
+                    ${selectedOrg.spent_usd.toFixed(2)} / ${selectedOrg.budget_usd.toFixed(2)}
+                  </p>
+                  <p className="text-xs text-muted-foreground">{selectedOrg.agent_count} agents</p>
+                </div>
+              </div>
+            </div>
+          </MnSectionCard>
+        )}
+
+        {selectedOrg && (
+          <MnSectionCard title="Inter-Org Peers" collapsible defaultOpen>
+            <div className="space-y-2 p-4">
+              {(peers ?? []).length > 0 ? (
+                (peers ?? []).map((p) => (
+                  <div key={p.peer_name} className="flex items-center justify-between border-b border-border py-2">
+                    <span className="text-sm font-medium">{p.peer_name}</span>
+                    <MnBadge tone={p.allowed ? 'success' : 'danger'}>
+                      {p.allowed ? 'Allowed' : 'Blocked'}
+                    </MnBadge>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-muted-foreground">No peer connections</p>
+              )}
+            </div>
+          </MnSectionCard>
+        )}
+      </div>
+
+      <MnModal open={showCreate} onOpenChange={setShowCreate} title="New Organization">
+        <div className="space-y-4 p-4">
+          <MnFormField label="Name" required error={!formData.name && saving ? 'Required' : undefined}>
+            <input
+              type="text"
+              value={formData.name}
+              onChange={(e) => setFormData((f) => ({ ...f, name: e.target.value }))}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+              placeholder="e.g. Legal Corp"
+            />
+          </MnFormField>
+          <MnFormField label="Description">
+            <input
+              type="text"
+              value={formData.description ?? ''}
+              onChange={(e) => setFormData((f) => ({ ...f, description: e.target.value }))}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+              placeholder="Legal research division"
+            />
+          </MnFormField>
+          <MnFormField label="Budget (USD)">
+            <input
+              type="number"
+              value={formData.budget_usd}
+              onChange={(e) => setFormData((f) => ({ ...f, budget_usd: Number(e.target.value) }))}
+              className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+              min={0}
+              step={10}
+            />
+          </MnFormField>
+          <div className="flex justify-end gap-2">
+            <button
+              onClick={() => setShowCreate(false)}
+              className="rounded-md border px-4 py-2 text-sm"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleCreate}
+              disabled={saving}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {saving ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </div>
+      </MnModal>
     </div>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -27,6 +27,13 @@ import type {
   PromptInput,
   Skill,
   SkillInput,
+  Org,
+  OrgInput,
+  OrgDelegation,
+  Plan,
+  PlanInput,
+  Wave,
+  MeshNode,
   ExtensionInfo,
   DepGraph,
   DepGraphValidation,
@@ -204,6 +211,46 @@ export const skillSearch = (q?: string, category?: string) =>
 
 export const skillCreate = (input: SkillInput) =>
   post<{ id: string }>('/api/skills', input);
+
+/* ── Organizations ── */
+
+export const orgList = () => get<Org[]>('/api/orgs');
+
+export const orgGet = (id: string) =>
+  get<Org>(`/api/orgs/${encodeURIComponent(id)}`);
+
+export const orgCreate = (input: OrgInput) =>
+  post<{ id: string }>('/api/orgs', input);
+
+export const orgUpdate = (id: string, input: OrgInput) =>
+  put<void>(`/api/orgs/${encodeURIComponent(id)}`, input);
+
+export const orgDelete = (id: string) =>
+  del<void>(`/api/orgs/${encodeURIComponent(id)}`);
+
+export const orgDelegations = (org_id: string) =>
+  get<OrgDelegation[]>(`/api/orgs/${encodeURIComponent(org_id)}/delegations`);
+
+/* ── Plans & Tasks ── */
+
+export const planList = (p?: { org_id?: string; status?: string }) =>
+  get<Plan[]>(`/api/plans${qs(p ?? {})}`);
+
+export const planGet = (id: string) =>
+  get<Plan>(`/api/plans/${encodeURIComponent(id)}`);
+
+export const planCreate = (input: PlanInput) =>
+  post<{ id: string }>('/api/plans', input);
+
+export const planWaves = (plan_id: string) =>
+  get<Wave[]>(`/api/plans/${encodeURIComponent(plan_id)}/waves`);
+
+/* ── Mesh ── */
+
+export const meshNodes = () => get<MeshNode[]>('/api/mesh/nodes');
+
+export const meshNodeGet = (id: string) =>
+  get<MeshNode>(`/api/mesh/nodes/${encodeURIComponent(id)}`);
 
 /* ── Multitenancy ── */
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -129,6 +129,73 @@ export interface Skill {
 }
 export interface SkillInput { name: string; description: string; category?: string; capabilities: string[] }
 
+/* ── Organizations ── */
+export interface Org {
+  id: string;
+  name: string;
+  description?: string;
+  status: 'active' | 'suspended' | 'archived';
+  budget_usd: number;
+  spent_usd: number;
+  agent_count: number;
+  created_at: string;
+}
+export interface OrgInput {
+  name: string;
+  description?: string;
+  budget_usd: number;
+}
+export interface OrgDelegation {
+  id: string;
+  from_org: string;
+  to_org: string;
+  capability: string;
+  status: 'active' | 'revoked';
+  created_at: string;
+}
+
+/* ── Plans & Tasks ── */
+export interface Plan {
+  id: string;
+  name: string;
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  wave_count: number;
+  task_count: number;
+  completed_tasks: number;
+  created_at: string;
+  org_id?: string;
+}
+export interface PlanInput { name: string; org_id?: string; description?: string }
+export interface Wave {
+  id: string;
+  plan_id: string;
+  index: number;
+  status: 'pending' | 'in_progress' | 'completed';
+  tasks: Task[];
+}
+export interface Task {
+  id: string;
+  plan_id: string;
+  wave_id: string;
+  name: string;
+  status: 'pending' | 'in_progress' | 'submitted' | 'done' | 'failed';
+  assignee?: string;
+  evidence?: string[];
+  thor_validated?: boolean;
+  created_at: string;
+}
+
+/* ── Mesh ── */
+export interface MeshNode {
+  id: string;
+  name: string;
+  url: string;
+  status: 'online' | 'offline' | 'syncing';
+  last_sync?: string;
+  schema_version?: string;
+  latency_ms?: number;
+}
+
 /* ── Multitenancy ���─ */
 export interface PeerEntry { peer_name: string; peer_url?: string; allowed: boolean }
 export interface AuditEntry {


### PR DESCRIPTION
## Summary
- Full organizations page with CRUD (create, view, delete)
- OrgChart visualization using MnOrgChart
- Budget distribution treemap
- Inter-org peers view with allow/block status
- Org detail panel with budget progress ring
- Added Org, OrgInput, OrgDelegation, Plan, Task, Wave, MeshNode types
- Added org CRUD API functions

## Test plan
- [ ] pnpm typecheck passes
- [ ] pnpm build succeeds
- [ ] /orgs page loads and shows org list
- [ ] Create org modal works
- [ ] Org detail shows budget and peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)