### PR TITLE
fix: fase 11 — wiring audit and lint cleanup

### DIFF
--- a/src/app/(dashboard)/observatory/page.tsx
+++ b/src/app/(dashboard)/observatory/page.tsx
@@ -5,18 +5,10 @@ import { useApiQuery } from '@/hooks/use-api-query';
 import * as api from '@/lib/api';
 import type { TimelineEvent, Anomaly, ObservatoryDashboard } from '@/lib/types';
 import { MnSectionCard } from '@/components/maranello/layout';
-import { MnDataTable, type DataTableColumn, MnBadge } from '@/components/maranello/data-display';
+import { MnBadge } from '@/components/maranello/data-display';
 import { MnChart } from '@/components/maranello/data-viz';
 import { MnActivityFeed, type ActivityItem } from '@/components/maranello/feedback';
 import { MnStateScaffold } from '@/components/maranello/feedback';
-
-const ANOMALY_COLS: DataTableColumn[] = [
-  { key: 'kind', label: 'Kind', sortable: true },
-  { key: 'severity', label: 'Severity', type: 'status', sortable: true },
-  { key: 'message', label: 'Message' },
-  { key: 'detected_at', label: 'Detected', sortable: true },
-  { key: 'resolved', label: 'Resolved' },
-];
 
 export default function ObservatoryPage() {
   const [searchQuery, setSearchQuery] = useState('');


### PR DESCRIPTION
## Summary
- Remove unused `MnDataTable` import and `ANOMALY_COLS` from observatory page
- Wiring audit: all 10 dashboard routes match convergio.yaml navigation
- Quality gate: 0 TS errors, 12 pre-existing warnings, 96 tests pass, build OK

## Test plan
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm lint` — zero errors (12 pre-existing warnings, none in our pages)
- [x] `pnpm test` — 96 tests pass
- [x] `pnpm build` — all routes compile
- [x] Route audit: every nav item has a page.tsx, every page is in convergio.yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)