### PR TITLE
feat(dashboard): show discovered external agents

### DIFF
--- a/src/app/(dashboard)/discovered-agents.tsx
+++ b/src/app/(dashboard)/discovered-agents.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import type { DiscoveredAgent } from '@/lib/types';
+import { MnBadge } from '@/components/maranello/data-display';
+
+/* ── Badge tone by agent type ── */
+
+function typeTone(t: string): 'info' | 'success' | 'warning' {
+  if (t.includes('claude')) return 'info';
+  if (t.includes('mlx')) return 'success';
+  if (t.includes('copilot')) return 'warning';
+  return 'info';
+}
+
+function typeLabel(t: string): string {
+  if (t.includes('claude')) return 'Claude';
+  if (t.includes('mlx')) return 'MLX';
+  if (t.includes('copilot')) return 'Copilot';
+  return t;
+}
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const sec = Math.floor(diff / 1_000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  return `${Math.floor(min / 60)}h ago`;
+}
+
+/* ── Component ── */
+
+export function DiscoveredAgentsList({
+  agents,
+}: {
+  agents: DiscoveredAgent[];
+}) {
+  if (agents.length === 0) return null;
+
+  return (
+    <div className="mt-4 border-t border-dashed border-border pt-4">
+      <p className="mb-2 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+        Discovered External Agents
+      </p>
+      <div className="space-y-2">
+        {agents.map((a) => (
+          <div
+            key={`${a.name}-${a.pid}`}
+            className="flex items-center gap-3 rounded-md border border-dashed border-border bg-muted/30 px-3 py-2"
+          >
+            <MnBadge tone={typeTone(a.agent_type)}>
+              {typeLabel(a.agent_type)}
+            </MnBadge>
+            <span className="text-sm font-medium">{a.name}</span>
+            <span className="text-xs text-muted-foreground">{a.host}</span>
+            {a.pid && (
+              <span className="text-xs tabular-nums text-muted-foreground">
+                PID {a.pid}
+              </span>
+            )}
+            {a.parent_agent && (
+              <span className="text-xs text-muted-foreground">
+                &larr; {a.parent_agent}
+              </span>
+            )}
+            <span className="ml-auto text-[0.65rem] tabular-nums text-muted-foreground">
+              {timeAgo(a.last_seen)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -11,6 +11,7 @@ import type {
   RuntimeWorker,
   CostSummary,
 } from '@/lib/types';
+import { DiscoveredAgentsList } from './discovered-agents';
 import { MnSectionCard } from '@/components/maranello/layout';
 import {
   MnSystemStatus,
@@ -356,7 +357,11 @@ export default function DashboardPage() {
       </div>
 
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <KpiCard label="Active Agents" value={runtime?.active_agents?.length ?? 0} />
+        <KpiCard
+          label="Active Agents"
+          value={(runtime?.active_agents?.length ?? 0) + (runtime?.discovered_agents?.length ?? 0)}
+          sub={runtime?.discovered_agents?.length ? `${runtime.discovered_agents.length} external` : undefined}
+        />
         <KpiCard label="Queue Depth" value={runtime?.queue_depth ?? 0} />
         <KpiCard
           label="Budget Spent"
@@ -481,6 +486,7 @@ export default function DashboardPage() {
         <MnSectionCard title="Active Agents" collapsible defaultOpen>
           <div className="p-4">
             <MnActiveMissions missions={missions} />
+            <DiscoveredAgentsList agents={runtime?.discovered_agents ?? []} />
           </div>
         </MnSectionCard>
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -31,8 +31,17 @@ export interface RuntimeWorker {
   task_id: number | null;
   workspace_path: string;
 }
+export interface DiscoveredAgent {
+  name: string;
+  agent_type: string;
+  host: string;
+  pid: number | null;
+  last_seen: string;
+  parent_agent: string | null;
+}
 export interface RuntimeView {
   active_agents: RuntimeWorker[];
+  discovered_agents: DiscoveredAgent[];
   queue_depth: number;
   total_budget_usd: number;
   total_spent_usd: number;


### PR DESCRIPTION
## Summary

- Add `DiscoveredAgent` interface and `discovered_agents` field to `RuntimeView` in types.ts
- New `DiscoveredAgentsList` component renders external agents with dashed-border cards, type badges (Claude/MLX/Copilot), host, PID, and relative last-seen time
- KPI card now counts both managed and discovered agents, showing external count as subtitle
- Agents rendered inside existing "Active Agents" section card

## Test plan

- [ ] Verify `pnpm typecheck` passes (confirmed locally)
- [ ] Check dashboard with daemon running at localhost:8420 — discovered agents should appear
- [ ] Verify empty state: no "Discovered External Agents" section when array is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)