### PR TITLE
feat(types): add NightAgentDef, NightRun, TrackedProject types and API client

### DIFF
--- a/src/lib/api-night-agents.ts
+++ b/src/lib/api-night-agents.ts
@@ -1,0 +1,118 @@
+/**
+ * Typed HTTP client for the night-agents daemon API.
+ *
+ * Mirrors daemon routes in convergio-night-agents/src/routes.rs.
+ * Reuses the shared request helpers from api.ts.
+ */
+
+import { ApiError } from '@/hooks/use-api-query';
+import type {
+  NightAgentDef,
+  NightAgentDefInput,
+  NightRun,
+  TrackedProject,
+  TrackedProjectInput,
+} from '@/types/night-agents';
+
+const BASE =
+  typeof window !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8420')
+    : (process.env.API_URL ?? 'http://localhost:8420');
+
+const AUTH_TOKEN =
+  typeof window !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_AUTH_TOKEN ?? '')
+    : (process.env.AUTH_TOKEN ?? '');
+
+async function request<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (body) headers['Content-Type'] = 'application/json';
+  if (AUTH_TOKEN) headers['Authorization'] = `Bearer ${AUTH_TOKEN}`;
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new ApiError(res.status, text);
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+function get<T>(path: string) {
+  return request<T>('GET', path);
+}
+function post<T>(path: string, body?: unknown) {
+  return request<T>('POST', path, body);
+}
+function put<T>(path: string, body?: unknown) {
+  return request<T>('PUT', path, body);
+}
+function del<T>(path: string) {
+  return request<T>('DELETE', path);
+}
+
+function qs(params: Record<string, string | number | boolean | undefined>) {
+  const entries = Object.entries(params).filter(
+    ([, v]) => v !== undefined,
+  );
+  if (entries.length === 0) return '';
+  return '?' + new URLSearchParams(
+    entries.map(([k, v]) => [k, String(v)]),
+  ).toString();
+}
+
+/* ── Agent definitions ── */
+
+export const nightAgentList = (p?: { limit?: number; offset?: number }) =>
+  get<NightAgentDef[]>(`/api/night-agents${qs(p ?? {})}`);
+
+export const nightAgentGet = (id: number) =>
+  get<NightAgentDef>(`/api/night-agents/${id}`);
+
+export const nightAgentCreate = (input: NightAgentDefInput) =>
+  post<{ id: number }>('/api/night-agents', input);
+
+export const nightAgentUpdate = (id: number, input: NightAgentDefInput) =>
+  put<void>(`/api/night-agents/${id}`, input);
+
+export const nightAgentDelete = (id: number) =>
+  del<void>(`/api/night-agents/${id}`);
+
+/* ── Runs ── */
+
+export const nightAgentTrigger = (id: number) =>
+  post<{ run_id: number }>(`/api/night-agents/${id}/trigger`);
+
+export const nightRunList = (
+  agentId: number,
+  p?: { limit?: number; offset?: number },
+) => get<NightRun[]>(`/api/night-agents/${agentId}/runs${qs(p ?? {})}`);
+
+export const nightRunsActive = () =>
+  get<NightRun[]>('/api/night-agents/runs/active');
+
+export const nightRunCancel = (agentId: number, runId: number) =>
+  post<void>(`/api/night-agents/${agentId}/runs/${runId}/cancel`);
+
+/* ── Tracked projects ── */
+
+export const trackedProjectList = (p?: {
+  limit?: number;
+  offset?: number;
+}) => get<TrackedProject[]>(`/api/night-agents/projects${qs(p ?? {})}`);
+
+export const trackedProjectCreate = (input: TrackedProjectInput) =>
+  post<{ id: number }>('/api/night-agents/projects', input);
+
+export const trackedProjectDelete = (id: number) =>
+  del<void>(`/api/night-agents/projects/${id}`);
+
+export const trackedProjectScan = (id: number) =>
+  post<{ ok: boolean }>(`/api/night-agents/projects/${id}/scan`);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
 export type { AppConfig, NavConfig, NavSection, NavItem, PageConfig, PageRow, PageBlock, KpiCardBlock, DataTableBlock, ActivityFeedBlock, StatListBlock, EmptyStateBlock, AIChatBlock, GaugeBlock, ChartBlock, GanttBlock, GanttBlockTask, KanbanBlock, FunnelBlock, HbarBlock, SpeedometerBlock, MapBlock, OkrBlock, OkrBlockObjective, OkrBlockKeyResult, SystemStatusBlock, DataTableMaranelloBlock } from "./config";
 export type { AgentConfig, AIConfig } from "./ai";
+export type { NightAgentDef, NightAgentDefInput, NightRun, RunStatus, TrackedProject, TrackedProjectInput } from "./night-agents";

--- a/src/types/night-agents.ts
+++ b/src/types/night-agents.ts
@@ -1,0 +1,74 @@
+/**
+ * Night-agents types — mirrors convergio-night-agents Rust crate types.
+ * See daemon/crates/convergio-night-agents/src/types.rs for source of truth.
+ */
+
+/* ── Agent definitions ── */
+
+export interface NightAgentDef {
+  id: number;
+  name: string;
+  org_id?: string;
+  description?: string;
+  schedule: string;
+  agent_prompt: string;
+  model: string;
+  enabled: boolean;
+  max_runtime_secs: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface NightAgentDefInput {
+  name: string;
+  org_id?: string;
+  description?: string;
+  schedule: string;
+  agent_prompt: string;
+  model?: string;
+  max_runtime_secs?: number;
+}
+
+/* ── Runs ── */
+
+export type RunStatus =
+  | 'pending'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+export interface NightRun {
+  id: number;
+  agent_def_id: number;
+  status: RunStatus;
+  node_name?: string;
+  pid?: number;
+  started_at?: string;
+  completed_at?: string;
+  outcome?: string;
+  error_message?: string;
+  tokens_used: number;
+  cost_usd: number;
+  worktree_path?: string;
+}
+
+/* ── Tracked projects ── */
+
+export interface TrackedProject {
+  id: number;
+  name: string;
+  repo_path: string;
+  remote_url?: string;
+  last_scan_at?: string;
+  last_scan_hash?: string;
+  scan_profile_json?: string;
+  enabled: boolean;
+  created_at: string;
+}
+
+export interface TrackedProjectInput {
+  name: string;
+  repo_path: string;
+  remote_url?: string;
+}


### PR DESCRIPTION
## Gamma Plan 25 — Task T3-01 (DB 545)

Adds TypeScript types and typed HTTP client for the night-agents daemon API.

### Types added (`src/types/night-agents.ts`)
- `NightAgentDef` / `NightAgentDefInput`
- `NightRun` / `RunStatus`
- `TrackedProject` / `TrackedProjectInput`

### API functions (`src/lib/api-night-agents.ts`)
- `nightAgentList`, `nightAgentGet`, `nightAgentCreate`, `nightAgentUpdate`, `nightAgentDelete`
- `nightAgentTrigger`, `nightRunList`, `nightRunsActive`, `nightRunCancel`
- `trackedProjectList`, `trackedProjectCreate`, `trackedProjectDelete`, `trackedProjectScan`

All types mirror `daemon/crates/convergio-night-agents/src/types.rs`. TSC passes clean.