### PR TITLE
feat: add /night-agents dashboard page with Maranello DS

### DIFF
--- a/convergio.yaml
+++ b/convergio.yaml
@@ -62,6 +62,7 @@ navigation:
         - { id: billing, label: Billing, href: /billing, icon: Receipt }
         - { id: observatory, label: Observatory, href: /observatory, icon: Activity }
         - { id: metrics, label: Metrics, href: /metrics, icon: BarChart3 }
+        - { id: night-agents, label: Night Agents, href: /night-agents, icon: Moon }
         - { id: prompts, label: Prompt Studio, href: /prompts, icon: Terminal }
 
     - label: System

--- a/src/app/(dashboard)/night-agents/night-agents-tables.tsx
+++ b/src/app/(dashboard)/night-agents/night-agents-tables.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useMemo } from 'react';
+import { MnSectionCard } from '@/components/maranello/layout';
+import { MnDataTable, type DataTableColumn, MnBadge } from '@/components/maranello/data-display';
+import type { NightAgentDef, NightAgentRun, TrackedProject } from '@/lib/types-night-agents';
+
+const STATUS_TONE: Record<string, 'success' | 'danger' | 'warning' | 'neutral' | 'info'> = {
+  success: 'success',
+  completed: 'success',
+  running: 'info',
+  pending: 'warning',
+  failed: 'danger',
+  cancelled: 'neutral',
+};
+
+function statusTone(s: string | null) {
+  return STATUS_TONE[s ?? ''] ?? 'neutral';
+}
+
+function formatTime(iso: string | null | undefined): string {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    });
+  } catch { return iso; }
+}
+
+function elapsed(startedAt: string | null): string {
+  if (!startedAt) return '—';
+  const ms = Date.now() - new Date(startedAt).getTime();
+  if (ms < 0) return '—';
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  return `${mins}m ${secs % 60}s`;
+}
+
+/* ── Agent Definitions Table ── */
+
+const DEF_COLS: DataTableColumn[] = [
+  { key: 'name', label: 'Name', sortable: true },
+  { key: 'schedule', label: 'Schedule', sortable: true },
+  { key: 'model', label: 'Model', sortable: true },
+  { key: 'enabled', label: 'Enabled' },
+  { key: 'last_status', label: 'Last Status' },
+  { key: 'last_run_at', label: 'Last Run', sortable: true },
+];
+
+function prepAgentDefs(defs: NightAgentDef[]): Record<string, unknown>[] {
+  return defs.map((d) => ({
+    ...d,
+    enabled: d.enabled ? '✓' : '✗',
+    last_status: d.last_status ?? '—',
+    last_run_at: formatTime(d.last_run_at),
+  }));
+}
+
+export function AgentDefsTable({ defs }: { defs: NightAgentDef[] }) {
+  const rows = useMemo(() => prepAgentDefs(defs), [defs]);
+  return (
+    <MnSectionCard title="Agent Definitions" badge={defs.length} collapsible defaultOpen>
+      <MnDataTable columns={DEF_COLS} data={rows} emptyMessage="No agent definitions" />
+    </MnSectionCard>
+  );
+}
+
+/* ── Active Runs Table ── */
+
+const RUN_COLS: DataTableColumn[] = [
+  { key: 'agent_name', label: 'Agent', sortable: true },
+  { key: 'status_badge', label: 'Status' },
+  { key: 'started_at_fmt', label: 'Started', sortable: true },
+  { key: 'duration', label: 'Duration' },
+];
+
+function prepRuns(runs: NightAgentRun[]): Record<string, unknown>[] {
+  return runs.map((r) => ({
+    ...r,
+    status_badge: r.status,
+    started_at_fmt: formatTime(r.started_at),
+    duration: elapsed(r.started_at),
+  }));
+}
+
+export function ActiveRunsTable({ runs }: { runs: NightAgentRun[] }) {
+  const rows = useMemo(() => prepRuns(runs), [runs]);
+  return (
+    <MnSectionCard title="Active Runs" badge={runs.length} collapsible defaultOpen>
+      <MnDataTable columns={RUN_COLS} data={rows} emptyMessage="No active runs" />
+    </MnSectionCard>
+  );
+}
+
+/* ── Tracked Projects Table ── */
+
+const PROJ_COLS: DataTableColumn[] = [
+  { key: 'name', label: 'Project', sortable: true },
+  { key: 'repo_path', label: 'Repository' },
+  { key: 'last_scan_at_fmt', label: 'Last Scan', sortable: true },
+  { key: 'enabled_label', label: 'Active' },
+];
+
+function prepProjects(projects: TrackedProject[]): Record<string, unknown>[] {
+  return projects.map((p) => ({
+    ...p,
+    last_scan_at_fmt: formatTime(p.last_scan_at),
+    enabled_label: p.enabled ? '✓' : '✗',
+  }));
+}
+
+export function TrackedProjectsTable({ projects }: { projects: TrackedProject[] }) {
+  const rows = useMemo(() => prepProjects(projects), [projects]);
+  return (
+    <MnSectionCard title="Tracked Projects" badge={projects.length} collapsible defaultOpen>
+      <MnDataTable columns={PROJ_COLS} data={rows} emptyMessage="No tracked projects" />
+    </MnSectionCard>
+  );
+}
+
+/* ── Badge helper (exported for page) ── */
+
+export function StatusBadge({ status }: { status: string | null }) {
+  return <MnBadge tone={statusTone(status)}>{status ?? 'unknown'}</MnBadge>;
+}

--- a/src/app/(dashboard)/night-agents/page.tsx
+++ b/src/app/(dashboard)/night-agents/page.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useApiQuery } from '@/hooks/use-api-query';
+import * as nightApi from '@/lib/api-night-agents';
+import type { NightAgentDef, NightAgentRun, TrackedProject } from '@/lib/types-night-agents';
+import { MnStateScaffold } from '@/components/maranello/feedback';
+import { MnBadge } from '@/components/maranello/data-display';
+import {
+  AgentDefsTable,
+  ActiveRunsTable,
+  TrackedProjectsTable,
+} from './night-agents-tables';
+
+const POLL_MS = 5_000;
+
+function formatRelative(iso: string | null | undefined): string {
+  if (!iso) return 'never';
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 0) return 'just now';
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ago`;
+}
+
+export default function NightAgentsPage() {
+  const {
+    data: defs,
+    loading: defsLoading,
+    error: defsError,
+    refetch: refetchDefs,
+  } = useApiQuery<NightAgentDef[]>(nightApi.nightAgentList, { pollInterval: POLL_MS });
+
+  const {
+    data: runs,
+    loading: runsLoading,
+    error: runsError,
+  } = useApiQuery<NightAgentRun[]>(nightApi.nightAgentActiveRuns, { pollInterval: POLL_MS });
+
+  const {
+    data: projects,
+    loading: projLoading,
+    error: projError,
+  } = useApiQuery<TrackedProject[]>(nightApi.nightAgentProjects, { pollInterval: POLL_MS });
+
+  const loading = defsLoading && runsLoading && projLoading;
+  const error = defsError || runsError || projError;
+
+  const kpis = useMemo(() => {
+    const totalAgents = defs?.length ?? 0;
+    const activeRuns = runs?.length ?? 0;
+    const trackedProjects = projects?.filter((p) => p.enabled).length ?? 0;
+    const lastRunTimes = (defs ?? [])
+      .map((d) => d.last_run_at)
+      .filter(Boolean) as string[];
+    const lastRun = lastRunTimes.length > 0
+      ? lastRunTimes.sort().reverse()[0]
+      : null;
+    return { totalAgents, activeRuns, trackedProjects, lastRun };
+  }, [defs, runs, projects]);
+
+  if (loading) return <MnStateScaffold state="loading" message="Loading night agents..." />;
+  if (error) return <MnStateScaffold state="error" message={error} onRetry={refetchDefs} />;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <h1 className="text-2xl font-bold">Night Agents</h1>
+        {kpis.activeRuns > 0 && (
+          <MnBadge tone="info">{kpis.activeRuns} running</MnBadge>
+        )}
+      </div>
+
+      {/* KPI Row */}
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <KpiCard label="Total Agents" value={kpis.totalAgents} />
+        <KpiCard label="Active Runs" value={kpis.activeRuns} warn={kpis.activeRuns > 0} />
+        <KpiCard label="Tracked Projects" value={kpis.trackedProjects} />
+        <KpiCard label="Last Run" value={formatRelative(kpis.lastRun)} />
+      </div>
+
+      {/* Agent Definitions */}
+      <AgentDefsTable defs={defs ?? []} />
+
+      {/* Active Runs */}
+      <ActiveRunsTable runs={runs ?? []} />
+
+      {/* Tracked Projects */}
+      <TrackedProjectsTable projects={projects ?? []} />
+    </div>
+  );
+}
+
+function KpiCard({ label, value, warn }: { label: string; value: string | number; warn?: boolean }) {
+  return (
+    <div className="rounded-lg border bg-card p-4">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className={`text-2xl font-bold tabular-nums ${warn ? 'text-primary' : ''}`}>{value}</p>
+    </div>
+  );
+}

--- a/src/lib/api-night-agents.ts
+++ b/src/lib/api-night-agents.ts
@@ -1,0 +1,49 @@
+/**
+ * API client for Night Agents endpoints (/api/night-agents/*).
+ * Separated from api.ts to respect 250-line limit.
+ */
+
+import type {
+  NightAgentDef,
+  NightAgentRun,
+  TrackedProject,
+} from './types-night-agents';
+
+const BASE =
+  typeof window !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8420')
+    : (process.env.API_URL ?? 'http://localhost:8420');
+
+const AUTH_TOKEN =
+  typeof window !== 'undefined'
+    ? (process.env.NEXT_PUBLIC_AUTH_TOKEN ?? '')
+    : (process.env.AUTH_TOKEN ?? '');
+
+async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  const headers: Record<string, string> = {};
+  if (body) headers['Content-Type'] = 'application/json';
+  if (AUTH_TOKEN) headers['Authorization'] = `Bearer ${AUTH_TOKEN}`;
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`API ${res.status}: ${text.slice(0, 100)}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json() as Promise<T>;
+}
+
+export const nightAgentList = () =>
+  request<NightAgentDef[]>('GET', '/api/night-agents');
+
+export const nightAgentActiveRuns = () =>
+  request<NightAgentRun[]>('GET', '/api/night-agents/runs/active');
+
+export const nightAgentProjects = () =>
+  request<TrackedProject[]>('GET', '/api/night-agents/projects');
+
+export const nightAgentTrigger = (id: number) =>
+  request<{ status: string }>('POST', `/api/night-agents/${id}/trigger`);

--- a/src/lib/types-night-agents.ts
+++ b/src/lib/types-night-agents.ts
@@ -1,0 +1,40 @@
+/**
+ * Types for the Night Agents dashboard.
+ * Maps to daemon API: /api/night-agents/*
+ */
+
+export interface NightAgentDef {
+  id: number;
+  name: string;
+  org_id: string | null;
+  description: string | null;
+  schedule: string;
+  model: string;
+  enabled: boolean;
+  max_runtime_secs: number;
+  created_at: string;
+  updated_at: string;
+  last_status: string | null;
+  last_run_at: string | null;
+}
+
+export interface NightAgentRun {
+  run_id: number;
+  agent_def_id: number;
+  agent_name: string;
+  status: string;
+  node_name: string | null;
+  pid: number | null;
+  started_at: string | null;
+}
+
+export interface TrackedProject {
+  id: number;
+  name: string;
+  repo_path: string;
+  remote_url: string | null;
+  last_scan_at: string | null;
+  last_scan_hash: string | null;
+  enabled: boolean;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
Creates the `/night-agents` dashboard page using Maranello DS components.

### What's included
- **KPI row**: total agents, active runs, tracked projects, last run time
- **Agent definitions table**: name, schedule, model, enabled status, last run
- **Active runs table**: agent name, status, started time, duration
- **Tracked projects table**: project name, repo path, last scan, active
- **Auto-refresh** every 5 seconds via `useApiQuery` `pollInterval`
- **Sidebar navigation** entry under Operations section (Moon icon)
- **API client** (`api-night-agents.ts`) and **types** (`types-night-agents.ts`)

### Files changed
| File | Lines | Purpose |
|------|-------|---------|
| `page.tsx` | 105 | Main page with KPI row and data fetching |
| `night-agents-tables.tsx` | 126 | Agent defs, runs, projects tables |
| `api-night-agents.ts` | 49 | API client for daemon endpoints |
| `types-night-agents.ts` | 40 | TypeScript interfaces |
| `convergio.yaml` | +1 | Sidebar nav entry |

### API endpoints consumed
- `GET /api/night-agents` — agent definitions
- `GET /api/night-agents/runs/active` — active runs
- `GET /api/night-agents/projects` — tracked projects

### Patterns followed
- Same `useApiQuery` + `MnDataTable` + `MnSectionCard` pattern as agents/billing pages
- All files under 250 lines

Plan 25, Task T3-02 (DB ID: 546)