### PR TITLE
fix: showTraffic wiring, reconnect timer leak, a11y duration, particle cap (#51-#54)

### DIFF
--- a/src/components/maranello/agentic/mn-brain-3d.scene.ts
+++ b/src/components/maranello/agentic/mn-brain-3d.scene.ts
@@ -32,6 +32,7 @@ export interface BrainSceneOpts {
   onNodeClick?: (node: Brain3DNode) => void
   onNodeHover?: (node: Brain3DNode | null) => void
   particleSize?: number
+  showTraffic?: boolean
 }
 
 export interface BrainSceneHandle {
@@ -43,7 +44,7 @@ export interface BrainSceneHandle {
 const BG = 0x080810
 
 export function createBrainScene(opts: BrainSceneOpts): BrainSceneHandle {
-  const { canvas, nodes, edges, palette, showLabels, reducedMotion, particleSize } = opts
+  const { canvas, nodes, edges, palette, showLabels, reducedMotion, particleSize, showTraffic } = opts
   let { width, height } = opts
 
   /* ── Core setup ─────────────────────────────────────────── */
@@ -117,14 +118,15 @@ export function createBrainScene(opts: BrainSceneOpts): BrainSceneHandle {
     const { tube, curve } = createConnectionCurve(from, to, edge, palette, src)
     scene.add(tube)
     if (reducedMotion) continue
-    const pCount = edge.particles ?? (edge.active ? 4 : 0)
+    const pCount = showTraffic ? (edge.particles ?? (edge.active ? 4 : 0)) : (edge.active ? 4 : 0)
     if (pCount <= 0) continue
     const pColor = edge.particleColor
       ? new Color(edge.particleColor)
       : new Color(nodeColor(src, palette))
     const speedBase = 0.001 + (edge.particleSpeed ?? 0.5) * 0.005
-    const count = Math.min(pCount, 20)
-    for (let p = 0; p < count; p++) {
+    // Cap total particles per edge at 20, split evenly if bidirectional
+    const perDir = edge.bidirectional ? Math.min(pCount, 10) : Math.min(pCount, 20)
+    for (let p = 0; p < perDir; p++) {
       const m = createTravelParticle(pColor, particleSize)
       scene.add(m)
       travelers.push({ mesh: m, curve, t: Math.random(), speed: speedBase + Math.random() * 0.002 })
@@ -132,7 +134,7 @@ export function createBrainScene(opts: BrainSceneOpts): BrainSceneHandle {
     if (edge.bidirectional) {
       const pts = curve.points
       const rev = new CatmullRomCurve3([pts[pts.length - 1].clone(), pts[1].clone(), pts[0].clone()])
-      for (let p = 0; p < count; p++) {
+      for (let p = 0; p < perDir; p++) {
         const m = createTravelParticle(pColor, particleSize)
         scene.add(m)
         travelers.push({ mesh: m, curve: rev, t: Math.random(), speed: speedBase + Math.random() * 0.002 })

--- a/src/components/maranello/agentic/mn-brain-3d.tsx
+++ b/src/components/maranello/agentic/mn-brain-3d.tsx
@@ -39,7 +39,7 @@ export function MnBrain3D({
   nodes, edges, onNodeClick, onNodeHover,
   autoRotate = true, autoRotateSpeed = 0.5, showLabels = true,
   height = 500, ariaLabel = "3D agent network visualization",
-  particleSize,
+  particleSize, showTraffic,
   size = "md", className, ...rest
 }: MnBrain3DProps) {
   const wrap = React.useRef<HTMLDivElement>(null)
@@ -60,7 +60,7 @@ export function MnBrain3D({
       handle.current = createBrainScene({
         canvas, nodes, edges, palette,
         width: w, height, showLabels, reducedMotion,
-        onNodeClick, onNodeHover, particleSize,
+        onNodeClick, onNodeHover, particleSize, showTraffic,
       })
     })
 
@@ -71,7 +71,7 @@ export function MnBrain3D({
           canvas, nodes, edges,
           palette: readBrain3DPalette(host),
           width: host.clientWidth || 400, height, showLabels, reducedMotion,
-          onNodeClick, onNodeHover, particleSize,
+          onNodeClick, onNodeHover, particleSize, showTraffic,
         })
       })
     })
@@ -84,7 +84,7 @@ export function MnBrain3D({
     ro?.observe(host)
 
     return () => { handle.current?.dispose(); themeObs.disconnect(); ro?.disconnect() }
-  }, [nodes, edges, height, showLabels, reducedMotion, onNodeClick, onNodeHover, particleSize])
+  }, [nodes, edges, height, showLabels, reducedMotion, onNodeClick, onNodeHover, particleSize, showTraffic])
 
   React.useEffect(() => {
     handle.current?.setAutoRotate(autoRotate, autoRotateSpeed)

--- a/src/components/maranello/agentic/mn-process-timeline.helpers.tsx
+++ b/src/components/maranello/agentic/mn-process-timeline.helpers.tsx
@@ -123,13 +123,17 @@ export function Connector({
   const isH = orientation === "horizontal";
 
   return (
-    <div
-      aria-hidden="true"
-      className={cn(
-        "flex items-center justify-center",
-        isH ? "flex-col mx-0.5 flex-1 min-w-6" : "flex-row my-0.5 min-h-6 self-center",
+    <>
+      {showDuration && duration && (
+        <span className="sr-only">{t.duration}: {duration}</span>
       )}
-    >
+      <div
+        aria-hidden="true"
+        className={cn(
+          "flex items-center justify-center",
+          isH ? "flex-col mx-0.5 flex-1 min-w-6" : "flex-row my-0.5 min-h-6 self-center",
+        )}
+      >
       <div
         className={cn(
           "transition-colors",
@@ -149,11 +153,10 @@ export function Connector({
           {duration}
         </span>
       )}
-    </div>
+      </div>
+    </>
   );
 }
-
-/* ── Vertical step node ── */
 
 export function VerticalStepNode({ step, size, animate, showActors, interactive, onClick }: StepNodeProps) {
   const t = useLocale("processTimeline");

--- a/src/hooks/use-event-source.ts
+++ b/src/hooks/use-event-source.ts
@@ -27,6 +27,7 @@ export function useEventSource<T>(
   const [error, setError] = useState<string | null>(null);
   const onMessageRef = useRef(onMessage);
   const retryRef = useRef(1000);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const connectRef = useRef<(() => (() => void) | undefined) | null>(null);
 
   useEffect(() => {
@@ -61,14 +62,17 @@ export function useEventSource<T>(
         setError("Connection lost");
         const delay = Math.min(retryRef.current, 30000);
         retryRef.current = delay * 2;
-        setTimeout(() => connectRef.current?.(), delay);
+        retryTimerRef.current = setTimeout(() => connectRef.current?.(), delay);
       };
 
       return () => source.close();
     };
 
     const cleanup = connectRef.current();
-    return cleanup;
+    return () => {
+      if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+      cleanup?.();
+    };
   }, [url, enabled]);
 
   return { data, connected, error };


### PR DESCRIPTION
## Fixes

### #51 — showTraffic prop never passed to scene
- Added `showTraffic` to `BrainSceneOpts`, forwarded from component
- Particle rendering now gated on `showTraffic` when using `edge.particles`

### #52 — Duration text inside aria-hidden connector
- Added `sr-only` span with duration text **outside** the `aria-hidden` container
- Screen readers now announce step durations (WCAG 1.3.1)

### #53 — useEventSource reconnect timer not cleared
- Store `setTimeout` ID in `retryTimerRef`
- Clear on unmount — prevents stacked retries and post-unmount reconnections

### #54 — Bidirectional edges could spawn 40 particles
- Cap total per edge at 20: `Math.min(pCount, 10)` per direction when bidirectional
- Unidirectional unchanged at `Math.min(pCount, 20)`

### Verification
- ✅ Lint: 0 errors, 0 warnings
- ✅ Typecheck: 0 errors
- ✅ Build: passes
- ✅ Tests: 98/98

Fixes #51, Fixes #52, Fixes #53, Fixes #54

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>