### PR TITLE
feat: dynamic block registry — decouple page-renderer from Maranello

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,10 @@
 import { AppShell } from '@/components/shell/app-shell';
 import { loadAppConfig, loadNavSections, loadLocaleOverrides } from '@/lib/config-loader';
 import { MnLocaleProvider } from '@/lib/i18n';
+import { MnA11yFab } from '@/components/maranello';
+
+/* Register all built-in Maranello block types for the PageRenderer */
+import '@/lib/block-registrations';
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const appConfig = loadAppConfig();
@@ -9,7 +13,12 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
 
   return (
     <MnLocaleProvider messages={localeOverrides}>
-      <AppShell sections={sections} brandName={appConfig.name} brandLogo={appConfig.logo}>
+      <AppShell
+        sections={sections}
+        brandName={appConfig.name}
+        brandLogo={appConfig.logo}
+        a11ySlot={<MnA11yFab />}
+      >
         {children}
       </AppShell>
     </MnLocaleProvider>

--- a/src/components/page-renderer.tsx
+++ b/src/components/page-renderer.tsx
@@ -1,27 +1,20 @@
+import { Suspense, createElement } from "react";
 import type { PageConfig, PageBlock } from "@/types";
 import { loadAIConfig } from "@/lib/config-loader";
+import { getBlock } from "@/lib/block-registry";
 import { KpiCard, DataTable, ActivityFeed, StatList, EmptyState, AIChatPanel } from "@/components/blocks";
-import {
-  MnGauge,
-  MnChart,
-  MnGantt,
-  MnKanbanBoard,
-  MnFunnel,
-  MnHbar,
-  MnSpeedometer,
-  MnMap,
-  MnOkr,
-  MnSystemStatus,
-  MnDataTable,
-  MnWorkflowOrchestrator,
-} from "@/components/maranello";
 
 /**
  * Page Renderer — transforms a PageConfig into rendered UI.
  *
- * Mobile-first responsive grid: single column on small screens,
- * configured columns on md+ breakpoints. Unknown block types
- * trigger a console.warn for debugging.
+ * Maranello block components are loaded from the dynamic block registry
+ * (see src/lib/block-registry.ts). Built-in blocks (kpi-card, data-table,
+ * activity-feed, stat-list, empty-state, ai-chat) are always available.
+ *
+ * To register Maranello blocks, import block-registrations.ts in your layout:
+ * ```ts
+ * import "@/lib/block-registrations";
+ * ```
  */
 
 /** Map column count to responsive Tailwind grid classes (mobile-first) */
@@ -53,12 +46,15 @@ export function PageRenderer({ config }: { config: PageConfig }) {
   );
 }
 
-const KNOWN_TYPES = new Set([
-  "kpi-card", "data-table", "activity-feed",
-  "stat-list", "empty-state", "ai-chat",
-]);
+/** Fallback shown while a lazy block component is loading. */
+function BlockFallback() {
+  return (
+    <div className="animate-pulse rounded-lg bg-[var(--mn-surface-sunken)] h-32" />
+  );
+}
 
 function BlockRenderer({ block }: { block: PageBlock }) {
+  /* Built-in blocks — always available, no registry needed */
   switch (block.type) {
     case "kpi-card":
       return <KpiCard {...block} />;
@@ -72,38 +68,27 @@ function BlockRenderer({ block }: { block: PageBlock }) {
       return <EmptyState {...block} />;
     case "ai-chat":
       return <AIChatPanel defaultAgentId={block.agentId} aiConfig={loadAIConfig()} />;
-    case "gauge-block":
-      return <MnGauge {...block} />;
-    case "chart-block": {
-      const { type: _blockType, chartType, ...rest } = block; // eslint-disable-line @typescript-eslint/no-unused-vars
-      return <MnChart type={chartType} {...rest} />;
-    }
-    case "gantt-block":
-      return <MnGantt {...block} />;
-    case "kanban-block":
-      return <MnKanbanBoard {...block} />;
-    case "funnel-block":
-      return <MnFunnel {...block} />;
-    case "hbar-block":
-      return <MnHbar {...block} />;
-    case "speedometer-block":
-      return <MnSpeedometer {...block} />;
-    case "map-block":
-      return <MnMap {...block} />;
-    case "okr-block":
-      return <MnOkr {...block} />;
-    case "system-status-block":
-      return <MnSystemStatus {...block} />;
-    case "data-table-maranello":
-      return <MnDataTable {...block} />;
-    case "workflow-orchestrator-block":
-      return <MnWorkflowOrchestrator {...block} />;
-    default: {
-      const unknownType = (block as { type: string }).type;
-      if (!KNOWN_TYPES.has(unknownType)) {
-        console.warn(`[PageRenderer] Unknown block type: "${unknownType}". Skipping.`);
-      }
-      return null;
-    }
+    default:
+      break;
   }
+
+  /* Registry blocks — Maranello components registered via block-registry */
+  return <RegistryBlock block={block} />;
+}
+
+function RegistryBlock({ block }: { block: PageBlock }) {
+  const Component = getBlock(block.type);
+  if (!Component) {
+    console.warn(`[PageRenderer] Unknown block type: "${block.type}". Is the component installed and registered?`);
+    return null;
+  }
+  /* chart-block needs type remapping: block.chartType → component's type prop */
+  const props = block.type === "chart-block"
+    ? (() => { const { type: _t, chartType, ...rest } = block; return { type: chartType, ...rest }; })() // eslint-disable-line @typescript-eslint/no-unused-vars
+    : block;
+  return (
+    <Suspense fallback={<BlockFallback />}>
+      {createElement(Component, props)}
+    </Suspense>
+  );
 }

--- a/src/components/shell/app-shell.tsx
+++ b/src/components/shell/app-shell.tsx
@@ -1,20 +1,21 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useState, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import { useLocale } from "@/lib/i18n";
 import { Sidebar, type NavSection } from "./sidebar";
 import { Header } from "./header";
-import { MnA11yFab } from "@/components/maranello";
 
 export interface AppShellProps {
   children: React.ReactNode;
   sections: NavSection[];
   brandName?: string;
   brandLogo?: string;
+  /** Optional slot for accessibility FAB (e.g. MnA11yFab). */
+  a11ySlot?: ReactNode;
 }
 
-export function AppShell({ children, sections, brandName, brandLogo }: AppShellProps) {
+export function AppShell({ children, sections, brandName, brandLogo, a11ySlot }: AppShellProps) {
   const t = useLocale("shell");
   const pathname = usePathname();
   // Start collapsed so mobile Sheet is closed on initial render
@@ -50,7 +51,7 @@ export function AppShell({ children, sections, brandName, brandLogo }: AppShellP
           </div>
         </main>
       </div>
-      <MnA11yFab />
+      {a11ySlot}
     </>
   );
 }

--- a/src/lib/block-registrations.ts
+++ b/src/lib/block-registrations.ts
@@ -1,0 +1,36 @@
+/**
+ * Default block registrations — registers all built-in Maranello block types.
+ *
+ * This file is imported by the framework-mode layout to ensure all block
+ * types are available to the PageRenderer. Consumer apps that use only
+ * specific components can skip this import and register blocks individually
+ * via their component's .register.ts sidecar.
+ *
+ * Import this file once in your app (e.g. in the dashboard layout):
+ * ```ts
+ * import "@/lib/block-registrations";
+ * ```
+ */
+import { lazyBlock } from "./block-registry";
+
+/* ── Maranello data-viz blocks ── */
+lazyBlock("gauge-block", () => import("@/components/maranello/data-viz/mn-gauge"), "MnGauge");
+lazyBlock("chart-block", () => import("@/components/maranello/data-viz/mn-chart"), "MnChart");
+lazyBlock("funnel-block", () => import("@/components/maranello/data-viz/mn-funnel"), "MnFunnel");
+lazyBlock("hbar-block", () => import("@/components/maranello/data-viz/mn-hbar"), "MnHbar");
+lazyBlock("speedometer-block", () => import("@/components/maranello/data-viz/mn-speedometer"), "MnSpeedometer");
+lazyBlock("map-block", () => import("@/components/maranello/network/mn-map"), "MnMap");
+
+/* ── Maranello data-display blocks ── */
+lazyBlock("data-table-maranello", () => import("@/components/maranello/data-display/mn-data-table"), "MnDataTable");
+
+/* ── Maranello ops blocks ── */
+lazyBlock("gantt-block", () => import("@/components/maranello/ops/mn-gantt"), "MnGantt");
+lazyBlock("kanban-block", () => import("@/components/maranello/ops/mn-kanban-board"), "MnKanbanBoard");
+lazyBlock("system-status-block", () => import("@/components/maranello/network/mn-system-status"), "MnSystemStatus");
+
+/* ── Maranello strategy blocks ── */
+lazyBlock("okr-block", () => import("@/components/maranello/strategy/mn-okr"), "MnOkr");
+
+/* ── Maranello agentic blocks ── */
+lazyBlock("workflow-orchestrator-block", () => import("@/components/maranello/agentic/mn-workflow-orchestrator"), "MnWorkflowOrchestrator");

--- a/src/lib/block-registry.ts
+++ b/src/lib/block-registry.ts
@@ -1,0 +1,62 @@
+import { type ComponentType, lazy, type LazyExoticComponent } from "react";
+
+/**
+ * Block Registry — dynamic component registration for PageRenderer.
+ *
+ * Instead of statically importing every Maranello component, blocks
+ * register themselves when installed. This enables consumers to install
+ * only the components they need (shadcn-style) while keeping the
+ * page-renderer working for any block type declared in YAML config.
+ *
+ * @example
+ * ```ts
+ * // In a component's register file (e.g. mn-gauge.register.ts):
+ * import { registerBlock } from "@/lib/block-registry";
+ * registerBlock("gauge-block", lazy(() => import("@/components/maranello/data-viz/mn-gauge")));
+ * ```
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type BlockComponent = ComponentType<any>;
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const registry = new Map<string, LazyExoticComponent<BlockComponent> | BlockComponent>();
+
+/** Register a block type with its component (eager or lazy). */
+export function registerBlock(
+  blockType: string,
+  component: LazyExoticComponent<BlockComponent> | BlockComponent,
+): void {
+  registry.set(blockType, component);
+}
+
+/** Look up a registered block component by type. Returns undefined if not registered. */
+export function getBlock(blockType: string): LazyExoticComponent<BlockComponent> | BlockComponent | undefined {
+  return registry.get(blockType);
+}
+
+/** Check whether a block type has been registered. */
+export function hasBlock(blockType: string): boolean {
+  return registry.has(blockType);
+}
+
+/** Get all registered block type names. */
+export function registeredBlockTypes(): string[] {
+  return [...registry.keys()];
+}
+
+/**
+ * Helper to create a lazy-loaded block registration.
+ * Ensures the dynamic import only triggers when the block is actually rendered.
+ */
+export function lazyBlock(
+  blockType: string,
+  importFn: () => Promise<{ [key: string]: BlockComponent }>,
+  exportName: string,
+): void {
+  const component = lazy(async () => {
+    const mod = await importFn();
+    return { default: mod[exportName] };
+  });
+  registerBlock(blockType, component);
+}


### PR DESCRIPTION
## Plan #2270 — W1: Decouple page-renderer

### Changes
- **T1-01**: Dynamic block registry (`src/lib/block-registry.ts`) with `registerBlock()`, `lazyBlock()`, `getBlock()` API. Page-renderer no longer statically imports any Maranello component.
- **T1-02**: `AppShell` accepts optional `a11ySlot` prop — no longer depends on `MnA11yFab` directly.
- **T1-03**: `src/lib/block-registrations.ts` registers all 12 built-in block types via lazy imports. Dashboard layout imports it for backward compatibility.

### Why
Prerequisite for extracting `@convergio/core` package. Consumer apps (like convergio-edu) will install only the Maranello components they need, and each component self-registers its block type.

### Checklist
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 98/98 pass
- [x] `pnpm build` — production build OK