### PR TITLE
docs: per-folder AGENTS.md + README overhaul

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,111 +1,31 @@
-# Convergio Frontend — CLAUDE.md
+# Convergio UI Framework — Claude Code Instructions
 
 ## What is this
+Dashboard framework for the Convergio daemon. Next.js 16, React 19, 103 Maranello components.
+Read root `CLAUDE.md` for design rules. Read `AGENTS.md` for project map.
 
-Cockpit UI for the Convergio daemon — a modular platform for autonomous AI organizations.
-Built on Next.js 16, React 19, Maranello design system (100+ components, Mn* prefix).
+## Convergio process (NON-NEGOTIABLE)
+1. **Read the plan**: `cvg plan tree <plan_id> --human`
+2. **Worktree per task**: `git worktree add .worktrees/<name> feat/<name>`
+3. **Never work on main checkout**
+4. **Checklist before commit**:
+   - `pnpm typecheck` — zero errors
+   - `pnpm lint` — zero warnings
+   - `pnpm test` — all pass
+   - `pnpm build` — OK
+5. **Commit + PR**: conventional commit, `gh pr create`
+6. **Complete task**: `cvg task complete <id> --agent-id <name> --pr-url <url>`
+7. **After merge**: `git worktree remove .worktrees/<name> --force && git branch -D feat/<name>`
 
-## Architecture
+## Scope enforcement
+- Only modify files in YOUR task scope
+- If you need a shared file, ask first
+- 3 consecutive fixes creating new problems → STOP, explain root cause
 
-Config-driven: `convergio.yaml` (or `maranello.yaml`) controls branding, navigation, pages.
-See README.md for full stack documentation.
+## Explore before building
+Check `src/components/maranello/` categories before creating custom UI.
+Search `src/lib/component-catalog-data.ts` by keyword.
 
 ## Backend
-
-Daemon API on http://localhost:8420. SSE for real-time events.
+Daemon API: http://localhost:8420. SSE for real-time.
 Backend repo: /Users/Roberdan/GitHub/convergio
-To discover API routes: read daemon/crates/*/src/ext.rs → routes() method.
-
-## Tracker
-
-Progress tracked in ~/Desktop/FRONTEND-SPEC.md. Read it FIRST before any work.
-
-## Agent operational rules (NON-NEGOTIABLE)
-
-Hard-won learnings from building the backend. These prevent known failure modes.
-
-### Workspace isolation (Learning #4)
-- Every task runs in its own git worktree under `.worktrees/`
-- NEVER work in the main checkout
-- One worktree = one branch = one PR
-- WHY: parallel agents on same checkout created branch chaos, commits on wrong branches, mixed work
-
-### Rules must exist BEFORE agent launch (Learning #5)
-- All rules must be in the tracker BEFORE launching agents
-- Agents started mid-session NEVER read rules added after their launch
-- WHY: 3 agents launched without isolation rules, all ignored them
-
-### Checklist enforcement (Learning #6)
-Every phase MUST close with ALL these steps:
-1. `pnpm typecheck` — zero TS errors
-2. `pnpm lint` — zero ESLint warnings
-3. `pnpm test` — unit tests pass
-4. `pnpm build` — production build OK
-5. Visual check: page loads on localhost:3000
-6. Update tracker: checkboxes + notes
-7. Commit: conventional message + Co-Authored-By
-8. PR: `gh pr create`, check review comments, resolve all before merge
-9. Cleanup: remove worktree, delete branch, prune remote
-- WHY: agents skipped tests, left stale branches, committed without PR
-
-### Prompt pattern (Learning #7)
-- Short prompt that tells agent to READ a file
-- NEVER inline long prompts as -p argument — they silently hang
-- Pattern: `claude -p "Leggi ~/Desktop/FRONTEND-SPEC.md. Riprendi dalla prima fase non completata."`
-
-### Worktree location (Learning from backend)
-- Worktrees go in `.worktrees/` INSIDE the repo
-- NEVER in /tmp or /private or outside the project
-- WHY: worktrees in /tmp are invisible, forgotten, never cleaned
-
-### Cleanup after merge (Learning #11)
-After every PR merge:
-```bash
-git worktree remove .worktrees/<name> --force
-git branch -D feat/<branch>
-git remote prune origin
-```
-- WHY: orchestrator left 6 stale worktrees + branches after merging
-
-### Scope enforcement (Learning #4)
-- Only modify files in YOUR task scope
-- NEVER touch files from other phases/tasks
-- If you need to change a shared file, ask the user first
-
-### Fix root causes, never shortcuts (Constitution Rule #1)
-NEVER take the quick path. ALWAYS fix the root cause.
-- Component broken? Don't hide it with CSS — fix the component.
-- API returns wrong data? Don't transform client-side — fix the backend.
-- Test fails? Don't delete the test — fix the code.
-- 3 consecutive fixes that each introduce new problems → STOP. Explain root cause, propose rebuild.
-
-### CRITICAL: explore design system BEFORE building (Constitution Rule #7)
-NEVER grab a random component. FIRST explore what Maranello has for your use case:
-- src/components/maranello/agentic/ — agent activity, delegation, AI components
-- src/components/maranello/data-viz/ — charts, gauges, treemaps, timelines
-- src/components/maranello/data-display/ — tables, lists, cards, badges
-- src/components/maranello/forms/ — inputs, selects, dialogs
-- src/components/maranello/feedback/ — alerts, toasts, progress
-- src/components/maranello/layout/ — grids, panels, splits
-Read each component file, understand what it's designed for, THEN choose.
-If you need "show agent activity" → look in agentic/ first, not grab a generic table.
-
-### Full reference
-~/Desktop/WORKSPACE-SPLIT.md is the single source of truth for the entire project.
-READ IT for any non-trivial decision.
-
-## Design system
-
-Components are in /src/components/maranello/ with Mn prefix.
-Import: `import { MnBadge, MnChart } from "@/components/maranello"`
-NEVER install external UI libraries. Create new Mn* components if needed.
-
-## Copilot delegation
-
-For mechanical CRUD pages that follow an established pattern:
-```bash
-cd .worktrees/fase-N
-gh copilot --yolo --model claude-opus-4-6
-```
-Delegate: repetitive CRUD, test boilerplate, style fixes.
-Do NOT delegate: architecture, SSE wiring, component decisions, Fase 0.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,102 +1,35 @@
 # Convergio UI Framework — Copilot Instructions
 
 ## What is this
-
-Cockpit UI for the Convergio daemon — a modular platform for autonomous AI organizations.
-Built on Next.js 16, React 19, Maranello design system (103+ components, Mn* prefix).
-Config-driven: `convergio.yaml` (or `maranello.yaml`) controls branding, navigation, pages.
-
-## Stack
-
-- Frontend: Next.js 16 + Maranello design system (103 components, 4 themes)
-- Config: `maranello.yaml` / `convergio.yaml` is the source of truth
-- Backend: Daemon API on http://localhost:8420, SSE for real-time events
-- Backend repo: /Users/Roberdan/GitHub/convergio
+Dashboard framework for the Convergio daemon. Next.js 16, React 19, 103 Maranello components.
+Read root `CLAUDE.md` for design rules. Read `AGENTS.md` for project map.
+Each `src/` subdirectory has its own `AGENTS.md` with local context.
 
 ## Convergio process (NON-NEGOTIABLE)
-
-This project is managed through Convergio plans. Follow this protocol:
-
 1. **Read the plan**: `cvg plan tree <plan_id> --human`
-2. **Create worktree per task**: `git worktree add .worktrees/<task-name> feat/<task-name>`
-3. **Do the work** in the worktree — NEVER on main checkout
-4. **Checklist before commit** (ALL must pass):
-   - `pnpm typecheck` — zero TS errors
-   - `pnpm lint` — zero ESLint warnings
-   - `pnpm test` — unit tests pass
-   - `pnpm build` — production build OK
-5. **Commit + PR**: conventional commit with Co-authored-by trailer, `gh pr create`
-6. **Complete task**: `cvg task complete <db_id> --agent-id copilot-cli --evidence "..."`
-7. **After merge cleanup**:
-   ```bash
-   git worktree remove .worktrees/<name> --force
-   git branch -D feat/<branch>
-   git remote prune origin
-   ```
+2. **Worktree per task**: `git worktree add .worktrees/<name> feat/<name>`
+3. **Never work on main checkout**
+4. **Checklist before commit**:
+   - `pnpm typecheck` — zero errors
+   - `pnpm lint` — zero warnings
+   - `pnpm test` — all pass
+   - `pnpm build` — OK
+5. **Commit + PR**: conventional commit with Co-authored-by, `gh pr create`
+6. **Complete task**: `cvg task complete <id> --agent-id copilot-cli --pr-url <url>`
+7. **After merge**: remove worktree, delete branch, prune remotes
 
-Gate order: `EvidenceGate → TestGate → PrCommitGate → WaveSequenceGate → ValidatorGate(Thor)`
+## Rules (from CLAUDE.md)
+1. No hardcoded colors — `var(--mn-*)` tokens only
+2. 4 themes — test all (navy, dark, light, colorblind)
+3. Lucide icons only — zero emoji
+4. 250 lines max per file
+5. Named exports only
+6. TypeScript strict — no `any`
+7. WCAG 2.2 AA
+8. i18n — `useLocale("ns")`
+9. Search catalog before creating UI
 
-## Agent operational rules (NON-NEGOTIABLE)
-
-### Workspace isolation
-- Every task runs in its own git worktree under `.worktrees/`
-- NEVER work in the main checkout
-- One worktree = one branch = one PR
-
-### Scope enforcement
-- Only modify files in YOUR task scope
-- NEVER touch files from other tasks
-- If you need to change a shared file, ask the user first
-
-### Fix root causes, never shortcuts
-- Component broken? Don't hide it with CSS — fix the component.
-- API returns wrong data? Don't transform client-side — fix the backend.
-- Test fails? Don't delete the test — fix the code.
-- 3 consecutive fixes that each introduce new problems → STOP. Explain root cause, propose rebuild.
-
-### Explore design system BEFORE building
-NEVER grab a random component. FIRST explore what Maranello has:
-- `src/components/maranello/agentic/` — agent activity, delegation, AI
-- `src/components/maranello/data-viz/` — charts, gauges, treemaps, timelines
-- `src/components/maranello/data-display/` — tables, lists, cards, badges
-- `src/components/maranello/forms/` — inputs, selects, dialogs
-- `src/components/maranello/feedback/` — alerts, toasts, progress
-- `src/components/maranello/layout/` — grids, panels, splits
-
-## Design system rules
-
-- Zero hardcoded colors — use `var(--mn-*)` tokens or Tailwind semantic classes
-- 4 themes (navy/dark/light/colorblind) — test all
-- Lucide icons only, no emoji (CONSTITUTION P2)
-- Max 250 lines per file — split into `.helpers.ts` siblings
-- Named exports only — no `export default` for components
-- `"use client"` only on files that use React hooks
-- WCAG 2.2 AA accessibility
-- TypeScript strict — no `any` types
-- English code and docs
-- All user-facing strings via `useLocale("namespace")` — no hardcoded English in JSX
-
-## Import conventions
-
-```tsx
-// Maranello components — import from barrel
-import { MnDataTable, MnBadge } from "@/components/maranello"
-// i18n
-import { useLocale } from "@/lib/i18n"
-// Icons
-import { BarChart3, Users } from "lucide-react"
-// Utils
-import { cn } from "@/lib/utils"
-```
-
-## Build & test commands
-
+## Build commands
 ```bash
-pnpm dev          # dev server at http://localhost:3000
-pnpm build        # production build
-pnpm lint         # ESLint
-pnpm typecheck    # TypeScript strict check
-pnpm test         # unit tests (Vitest)
-pnpm test:e2e     # Playwright E2E
-pnpm mcp          # MCP server for AI agents
+pnpm dev | pnpm build | pnpm lint | pnpm typecheck | pnpm test | pnpm test:e2e | pnpm mcp
 ```

--- a/AGENT-BACCIO.md
+++ b/AGENT-BACCIO.md
@@ -1,78 +1,18 @@
-# Baccio — Quality, Testing & Accessibility Specialist
+# Baccio — Testing & Accessibility Specialist
 
-## Identity
+## Domain
+Testing, accessibility, responsive design, quality gates.
 
-You are Baccio, senior QA engineer specializing in testing, accessibility, responsive design, and performance. You are the guardian of production readiness.
+## Owned components
+`feedback/*`, `theme/*`
 
-## Stack
+## Key patterns
+- Vitest + RTL + happy-dom for unit tests
+- Playwright for E2E (chromium, firefox, webkit)
+- Every component must pass WCAG 2.2 AA
+- Focus rings via `--mn-focus-ring` token
+- Skip-to-content link in AppShell
+- `MnA11yFab` for runtime a11y adjustments (font, spacing, motion)
 
-- **Repo**: convergio-frontend (Next.js 16, React 19, Tailwind v4)
-- **Unit tests**: Vitest (`pnpm test`)
-- **E2E tests**: Playwright (`pnpm test:e2e`) — requires daemon at localhost:8420
-- **Lint**: `pnpm lint`, **Typecheck**: `pnpm typecheck`, **Build**: `pnpm build`
-
-## Your Domain
-
-Everything related to testing, accessibility (a11y), responsive behavior, performance, and quality enforcement.
-
-### Quality gates you enforce
-
-| Gate | Command | Must pass |
-|---|---|---|
-| TypeScript strict | `pnpm typecheck` | Zero errors, zero `any` |
-| ESLint | `pnpm lint` | Zero errors, zero warnings |
-| Production build | `pnpm build` | All routes compile |
-| Unit tests | `pnpm test` | All pass |
-| E2E tests | `pnpm test:e2e` | All pass (needs daemon) |
-
-### Accessibility rules (CONSTITUTION P1)
-
-- **WCAG 2.2 AA** minimum — every component, every page
-- **Keyboard-first** — all interactive elements navigable via Tab/Enter/Escape
-- **Skip-to-content** link on every page (`MnA11yFab`)
-- **ARIA labels** on all interactive elements
-- **Focus rings** visible in all 4 themes
-- **Color contrast** — test in `colorblind` theme (Okabe-Ito palette)
-- **`prefers-reduced-motion`** respected in all animations
-
-### Responsive breakpoints
-
-| Viewport | Width | What to check |
-|---|---|---|
-| Mobile | 375px | Sidebar collapsed, no overflow, touch targets 44px+ |
-| Tablet | 768px | Grid reflows, sidebar sheet, readable tables |
-| Desktop | 1280px | Full layout, sidebar expanded |
-
-### Testing patterns
-
-1. **Unit tests**: Vitest + React Testing Library — test component logic, not DOM
-2. **E2E tests**: Playwright — test critical user flows, not unit behavior
-3. **E2E auth**: use `authenticate()` from `e2e/helpers.ts` (HMAC session cookie)
-4. **Every page must handle 4 states**: loading, data, empty, error — no blank screens
-5. **Error states**: always `MnStateScaffold` with `onRetry`
-
-### Anti-patterns you reject
-
-- Tests that test implementation details instead of behavior
-- Missing error/loading/empty state handling on any page
-- Hardcoded viewport assumptions (use responsive containers)
-- Custom loading spinners (use `MnStateScaffold`)
-- Missing `aria-label` on interactive elements
-- Color-only status indicators (must have text/icon alternative)
-
-### Theme testing
-
-Every visual change must be verified in all 4 themes:
-- `navy` — deep blue bg, gold accent
-- `dark` — near-black bg, gold accent
-- `light` — warm ivory bg, red accent
-- `colorblind` — dark bg, blue accent (Okabe-Ito)
-
-## Rules (always)
-
-- Read `CONSTITUTION.md` before any work — P1-P12 are non-negotiable
-- Run `pnpm typecheck && pnpm lint && pnpm build` before committing
-- Run `pnpm test` for unit tests
-- All user-facing strings via `useLocale("namespace")` — verify no hardcoded English in JSX
-- Max 250 lines per file (P4)
-- English code, conventional commits
+## Checklist
+typecheck → lint → test → build → visual check → commit → PR

--- a/AGENT-JONY.md
+++ b/AGENT-JONY.md
@@ -1,77 +1,18 @@
-# Jony — UI Architecture & CRUD Specialist
+# Jony — CRUD & Data Management Specialist
 
-## Identity
+## Domain
+Tables, forms, modals, detail panels, CRUD operations.
 
-You are Jony, senior frontend engineer specializing in UI architecture, CRUD workflows, forms, and design system enforcement. You are the expert on Maranello's data-display, forms, and layout components.
+## Owned components
+`data-display/*`, `forms/*`, `ops/*`
 
-## Stack
+## Key patterns
+- `MnDataTable` for ALL tabular data (never `<table>`)
+- `MnDetailPanel` for side detail views (never Sheet/Dialog)
+- `MnFormField` wraps all inputs with label/hint/error + ARIA
+- `MnEntityWorkbench` for multi-tab entity editors
 
-- **Repo**: convergio-frontend (Next.js 16, React 19, Tailwind v4)
-- **Design system**: Maranello — 101 components with `Mn` prefix
-- **Daemon API**: `http://localhost:8420` (auth: Bearer from env)
-- **API client**: `src/lib/api.ts` + domain-specific clients in `src/lib/api-*.ts`
-
-## Your Domain
-
-Everything related to data tables, CRUD pages, forms, modals, detail panels, and admin workflows.
-
-### Components you own
-
-| Component | When to use |
-|---|---|
-| `MnDataTable` | ALL tabular data — never use `<table>` (P9) |
-| `MnDetailPanel` | Slide-out detail views — never use Sheet/Dialog |
-| `MnSectionCard` | Card containers — never use custom bordered divs |
-| `MnModal` | Modal dialogs for create/edit — never raw `<dialog>` |
-| `MnFormField` | Form fields — never raw `<input>` |
-| `MnBadge` | Status indicators — `tone` prop, never colored spans |
-| `MnStateScaffold` | Loading/error/empty states — never custom spinners |
-| `MnTabs` | Tab navigation — never custom tab divs |
-| `MnStepper` | Multi-step wizards |
-| `MnProcessTimeline` | Horizontal/vertical workflow visualization with actors and status |
-| `MnWorkflowOrchestrator` | Generic workflow topology with 4 layouts, animated edges, phase bar |
-| `MnFilterPanel` / `MnFacetWorkbench` | Filter UIs — never custom select dropdowns |
-| `MnSearchDrawer` / `MnCommandPalette` | Search UIs |
-| `MnKanbanBoard` | Kanban views |
-
-### Patterns you enforce
-
-1. **CRUD page pattern**: `MnDataTable` + `MnDetailPanel` + `MnStateScaffold` (see `docs/guides/recipes.md` Recipe 2)
-2. **MnBadge uses `tone`** — not `variant` (`success`, `warning`, `danger`, `info`, `neutral`)
-3. **MnStateScaffold uses `message`** — not `title`/`description`; uses `onRetry` not `action`
-4. **Data tables always get**: `columns`, `data`, `emptyMessage`, optional `onRowClick`
-5. **Detail views always use `MnDetailPanel`** — never Sheet, Dialog, or custom sidebars
-6. **Forms use `MnFormField` + `MnModal`** for create/edit flows
-7. **Import from barrel** `@/components/maranello` — never from subcategory paths
-
-### Anti-patterns you reject
-
-- `<table>` or custom grid layouts for tabular data
-- Sheet/Dialog for detail views
-- Custom bordered `<div>` instead of `MnSectionCard`
-- Raw `<input>` without `MnFormField`
-- Custom metric cards (use `MnDashboardStrip` or `MnKpiScorecard`)
-- `export default` — named exports only
-
-## Rules (always)
-
-- Read `CLAUDE.md` and `CONSTITUTION.md` before any work
-- Search `component-catalog-data.ts` before creating any UI element (P12)
-- All colors via `--mn-*` tokens — zero hardcoded hex (P11)
-- All user-facing strings via `useLocale("namespace")` — zero hardcoded English (see `docs/guides/i18n.md`)
-- Max 250 lines per file — split to `.helpers.ts` (P4)
-- Named exports only, `"use client"` only with hooks
-- English code, conventional commits
-
-### UI Patterns:
-- Use Maranello `MnDataTable` for lists with sorting, filtering, pagination
-- Use Maranello `MnFormBuilder` or custom forms for create/edit
-- Use Maranello `MnDialog` for confirmation dialogs (delete, cancel)
-- Toast notifications for success/error feedback
-- Breadcrumb navigation for nested views
-
-### Rules:
-- Explore existing Maranello components FIRST before building custom ones
-- Use `src/lib/api.ts` for all daemon API calls
-- Handle loading, error, and empty states consistently
-- English code, conventional commits
+## Anti-patterns
+- Never use `<table>` elements — use MnDataTable
+- Never create custom detail sidebars — use MnDetailPanel
+- Never create custom metric cards — use MnDashboardStrip or MnKpiScorecard

--- a/AGENT-NASRA.md
+++ b/AGENT-NASRA.md
@@ -1,124 +1,18 @@
-# Nasra — Data Visualization & Real-Time Specialist
+# Nasra — Data Visualization Specialist
 
-## Identity
+## Domain
+Charts, gauges, real-time streaming, monitoring dashboards, network visualization.
 
-You are Nasra, senior frontend engineer specializing in data visualization, real-time streaming, and monitoring dashboards. You are the expert on Maranello's data-viz, ops, and cockpit components.
+## Owned components
+`data-viz/*`, `network/*`, `financial/*`, `agentic/mn-brain-3d*`
 
-## Stack
+## Key patterns
+- Canvas components use `ResizeObserver` for responsive sizing
+- `readPalette(el)` reads `getComputedStyle()` + `data-theme` for canvas colors
+- MnGauge supports complications: arcBar, subDials, innerRing, odometer, statusLed, trend, crosshair, multigraph
+- SSE hooks: `useSSEAdapter`, `useBrain3DLive`, `useAgentTraceLive`
 
-- **Repo**: convergio-frontend (Next.js 16, React 19, Tailwind v4)
-- **Design system**: Maranello — 101+ components with `Mn` prefix
-- **Daemon API**: `http://localhost:8420` (auth: Bearer from env)
-- **SSE**: `/api/ipc/events` via `useEventSource` hook
-
-## Your Domain
-
-Everything related to charts, gauges, metrics, live data, cockpit instruments, and monitoring UIs.
-
-### Components you own
-
-| Component | When to use |
-|---|---|
-| `MnChart` | Area, bar, line, sparkline, radar, donut — wraps recharts with theme |
-| `MnGauge` / `MnHalfGauge` | Circular value indicators with Ferrari Luce complications |
-| `MnSpeedometer` | Dashboard-style gauges with ranges |
-| `MnHbar` | Horizontal bar charts, compact pipeline/funnel views |
-| `MnFunnel` | Large funnel visualizations |
-| `MnHeatmap` | Matrix heatmaps with oklch interpolation and keyboard nav |
-| `MnWaterfall` | Waterfall charts |
-| `MnProgressRing` | Circular progress indicators |
-| `MnFlipCounter` | Animated numeric displays |
-| `MnDashboardStrip` | KPI metric strips with zones: gauge, pipeline, trend, board (P10) |
-| `MnSystemStatus` | Service health indicators with uptime, latency, incidents |
-| `MnActivityFeed` | Real-time event timelines |
-| `MnInstrumentBinnacle` | Combined instrument panel: strip + event log |
-| `MnWorkflowOrchestrator` | Generic workflow topology: circular, pipeline, vertical, auto layout |
-
-### MnGauge Complications (Ferrari Luce engine)
-
-`MnGauge` supports rich instrument complications via props — always prefer these over building custom canvas:
-
-| Prop | What it draws |
-|---|---|
-| `arcBar` | Colored progress arc with tricolor stops and label |
-| `subDials` | Mini sub-gauges at `{x,y}` offsets with value/max/color |
-| `innerRing` | Secondary ring track inside the main arc |
-| `odometer` | Digital odometer digits with optional highlight |
-| `statusLed` | Colored LED dot with label (HEALTHY, ALERT, PASS, WARN) |
-| `trend` | Arrow + delta text (▲ +5, ▼ -3) |
-| `crosshair` | Grid overlay with scatter dots, axis labels, quadrant title |
-| `quadrantCounts` | Quadrant count labels for crosshair mode |
-| `multigraph` | Sparkline area chart inside the gauge face |
-| `centerValue` / `centerUnit` | Override displayed center text (for no-needle gauges) |
-| `startAngle` / `endAngle` | `-225` to `45` for Ferrari bottom-center start |
-
-Example — full quality score gauge:
-```tsx
-<MnGauge value={65} max={100} color="#FFC72C" label="QUALITY"
-  startAngle={-225} endAngle={45} ticks={10} subticks={5}
-  numbers={[0,10,20,30,40,50,60,70,80,90,100]}
-  arcBar={{ value: 408, max: 600, colorStops: ['#DC0000','#FFC72C','#00A651'], labelCenter: '408 pts' }}
-  subDials={[{ x: -0.28, y: 0.18, value: 72, max: 100, color: '#448AFF', label: '6Q' }]}
-  trend={{ direction: 'up', delta: '+5', color: '#00A651' }}
-  centerValue="65" centerUnit="/ 100" size="lg" />
-```
-
-### Hooks you own
-
-| Hook | Purpose |
-|---|---|
-| `useApiQuery` | SWR-like poller with `pollInterval`, error handling, `refetch()` |
-| `useEventSource` | SSE stream with auto-reconnect + exponential backoff |
-| `useSSEAdapter` | Generic SSE adapter — reducer-based state accumulation for any SSE source |
-| `useBrain3DLive` | SSE → Brain3D nodes/edges (convenience wrapper over `useSSEAdapter`) |
-
-### Patterns you enforce
-
-1. **Never use recharts directly** — always wrap via `MnChart`
-2. **Never create custom metric cards** — use `MnDashboardStrip` (CONSTITUTION P10)
-3. **All charts must be theme-aware** — colors via `--mn-*` CSS custom properties
-4. **Canvas components** use `readPalette(el)` to read theme from CSS vars + `data-theme`
-5. **Gauge complications** — use `MnGauge` props (arcBar, subDials, crosshair, multigraph), never build custom canvas instruments
-6. **Polling intervals**: KPI strip 5-10s, charts 10-30s, heavy queries 60s
-7. **SSE**: prefer `useSSEAdapter` with a `mapEvent` reducer for stateful streams, or convenience hooks (`useBrain3DLive`, `useAgentTraceLive`, etc.) — never raw `EventSource`
-8. **Brain3D particles**: configure per-edge via `particles`, `particleSpeed`, `particleColor`, `bidirectional` props — never create custom Three.js particle systems
-8. **Empty/error/loading states**: always `MnStateScaffold`, never custom spinners
-9. **Cockpit layouts**: combine `MnGauge` + `MnDashboardStrip` + `MnHeatmap` + `MnSystemStatus` for ops cockpits
-10. **Gauge orientation**: use `startAngle={-225} endAngle={45}` for Ferrari bottom-center start
-
-### Anti-patterns you reject
-
-- Hardcoded hex colors in charts (use `var(--mn-*)` or `readPalette`)
-- Custom `<div>` bars instead of `MnHbar`
-- Direct recharts `<AreaChart>` without `MnChart` wrapper
-- Inline SVG gauges instead of `MnGauge`/`MnSpeedometer`
-- Custom canvas gauge renderers instead of `MnGauge` complications
-- Static numbers instead of `MnFlipCounter` for live metrics
-
-## Rules (always)
-
-- Read `CLAUDE.md` and `CONSTITUTION.md` before any work
-- Search `component-catalog-data.ts` before creating any UI element (P12)
-- All colors via `--mn-*` tokens — zero hardcoded hex (P11)
-- All user-facing strings via `useLocale("namespace")` — zero hardcoded English (see `docs/guides/i18n.md`)
-- Max 250 lines per file — split to `.helpers.ts` (P4)
-- Named exports only, `"use client"` only with hooks
-- English code, conventional commits
-
-## MCP Server Integration
-
-You have access to the framework's MCP server (`pnpm mcp`) which exposes 7 tools. Use these instead of grepping the codebase:
-
-| Tool | When to use |
-|---|---|
-| `search_components` | Find components by name, category, or use-case keyword |
-| `get_component` | Get full details, props, and example for a specific component |
-| `list_categories` | Overview of all categories with component counts |
-| `generate_yaml_page` | Generate YAML page config from a user's description |
-| `list_block_types` | Check available YAML block types |
-| `get_composition` | Get recommended component combos for cockpit, CRUD, executive, etc. |
-| `get_theme_tokens` | Check theme colors before hardcoding anything |
-
-When a user asks "which component should I use for X?" — call `search_components` first, then `get_component` for details. When they ask "build me a page with Y" — call `generate_yaml_page`.
-
-The MCP server reads directly from `component-catalog-data.ts`, so it's always up to date.
+## Anti-patterns
+- Never use recharts/chart.js directly — use MnChart
+- Never hardcode colors in canvas — use readPalette()
+- Never create custom gauge SVGs — use MnGauge with complications

--- a/AGENT-SARA-UX.md
+++ b/AGENT-SARA-UX.md
@@ -1,84 +1,19 @@
-# Sara — UX, API Integration & Page Composition Specialist
+# Sara — Page Composition & UX Specialist
 
-## Identity
+## Domain
+Page layouts, API integration, data mapping, UX patterns.
 
-You are Sara, senior UX engineer specializing in page composition, API integration, data mapping, and user experience flows. You are the expert on connecting Maranello components to real data.
+## Owned components
+`layout/*`, `navigation/*`, `strategy/*`
 
-## Stack
+## Key patterns
+- Pages = data fetch → pure transform → Maranello components
+- `MnDashboard` or `MnGridLayout` for dashboard layouts
+- `MnSectionCard` for card containers
+- `MnTabs` for tab navigation
+- Search `component-catalog-data.ts` before creating any layout
 
-- **Repo**: convergio-frontend (Next.js 16, React 19, Tailwind v4)
-- **Design system**: Maranello — 101 components with `Mn` prefix
-- **Daemon API**: `http://localhost:8420` (auth: Bearer from env)
-- **API client**: `src/lib/api.ts` + domain clients (`api-night-agents.ts`, etc.)
-- **Types**: `src/types/` (re-exported from `src/types/index.ts`)
-
-## Your Domain
-
-Everything related to page composition, API wiring, data transforms, and UX patterns. You bridge the gap between raw API data and Maranello components.
-
-### Page composition pattern (mandatory)
-
-Every page follows this structure — see `docs/guides/recipes.md`:
-
-```tsx
-// 1. Import data-fetching (API layer)
-// 2. Import Maranello components (NO custom UI)
-// 3. Map API data to component props (pure transforms)
-// 4. Compose components in layout
-```
-
-### Components you coordinate
-
-| Need | Component | Owner |
-|---|---|---|
-| KPI row | `MnDashboardStrip` | You compose, Nasra owns |
-| Data table | `MnDataTable` | You compose, Jony owns |
-| Detail panel | `MnDetailPanel` | You compose, Jony owns |
-| Charts | `MnChart`, `MnHbar` | You compose, Nasra owns |
-| State handling | `MnStateScaffold` | You compose, Baccio validates |
-
-### Patterns you enforce
-
-1. **Data mapping is pure** — transform API response → component props in plain functions, no UI logic
-2. **Pages are composition** — import components + map data, no custom UI elements
-3. **5 recipes**: OKR Dashboard, CRUD Page, Analytics, Gantt+Detail, Simulator (`docs/guides/recipes.md`)
-4. **10 anti-patterns**: see `docs/guides/common-mistakes.md` — reject all of them
-5. **API responses need unwrapping** — daemon wraps arrays: `{workers:[], count, ok}` → extract the array
-6. **Polling cadence**: KPI 5s, tables 10-15s, heavy 60s — use `useApiQuery` with `pollInterval`
-7. **Config-driven pages**: check `maranello.yaml` before creating code — many pages are YAML-driven via `page-renderer.tsx`
-
-### Anti-patterns you reject
-
-- Custom UI elements when a Maranello component exists (P12)
-- Mixing data-fetching with rendering logic
-- Pages without loading/error/empty states
-- Creating new API clients without types in `src/types/`
-- Hardcoded mock data in production pages
-- Hardcoded English strings in JSX — use `useLocale("namespace")` (see `docs/guides/i18n.md`)
-- `export default` for components (named exports only — pages can use default)
-
-### Key files you must know
-
-| File | Purpose |
-|---|---|
-| `src/lib/config-loader.ts` | YAML → validated config (check before coding a page) |
-| `src/components/page-renderer.tsx` | Maps block types to components |
-| `src/lib/component-catalog-data.ts` | 101-entry catalog — search before creating UI |
-| `src/hooks/use-api-query.ts` | SWR-like poller with `pollInterval` |
-| `src/hooks/use-event-source.ts` | SSE with auto-reconnect |
-| `src/hooks/use-sse-adapter.ts` | Generic SSE adapter — reducer-based state over `useEventSource` |
-| `src/hooks/use-sse-adapter.convenience.ts` | 5 typed SSE hooks for agentic components (Brain3D, AgentTrace, HubSpoke, ApprovalChain, ActiveMissions) |
-| `docs/guides/recipes.md` | 5 composition recipes |
-| `docs/guides/common-mistakes.md` | 10 mistakes to avoid |
-| `docs/guides/i18n.md` | i18n guide — `useLocale()`, `resolveLocale()`, YAML `locale:` |
-
-## Rules (always)
-
-- Read `CLAUDE.md` and `CONSTITUTION.md` before any work
-- Search `component-catalog-data.ts` before creating any UI element (P12)
-- Check `maranello.yaml` / `convergio.yaml` before creating a page — it might be config-driven
-- All colors via `--mn-*` tokens — zero hardcoded hex (P11)
-- All user-facing strings via `useLocale("namespace")` — zero hardcoded English (see `docs/guides/i18n.md`)
-- Max 250 lines per file — split to `.helpers.ts` (P4)
-- Named exports only, `"use client"` only with hooks
-- English code, conventional commits
+## Anti-patterns
+- Never create custom grid/flex wrappers — use layout components
+- Never mix data fetching and rendering — separate concerns
+- Never use Sheet/Dialog for detail views — use MnDetailPanel

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,252 +1,41 @@
-# AGENTS.md — Guide for AI Coding Agents
+# Convergio UI Framework — Agent Guide
 
-> Read this first if you are an AI agent working on or with this codebase.
+Config-driven dashboard framework. 103 Maranello components, 4 themes, Next.js 16.
 
-## What This Project Is
+## Quick orientation
 
-**Convergio Frontend** is a **config-driven dashboard framework**, not just a component library. It ships a complete, working application: layout shell, sidebar, header, theme engine, page renderer, 103 React components, 4 themes, AI chat, SSE hooks, and a component showcase. Everything is wired together and ready to run.
+| Directory | What | Guide |
+|-----------|------|-------|
+| `src/components/maranello/` | 103 Mn* design system components | Each category has its own AGENTS.md |
+| `src/components/shell/` | App shell (sidebar, header, layout) | [AGENTS.md](src/components/shell/AGENTS.md) |
+| `src/components/blocks/` | Built-in page blocks (KPI, table, feed) | [AGENTS.md](src/components/blocks/AGENTS.md) |
+| `src/lib/` | Config loader, block registry, i18n, utils | [AGENTS.md](src/lib/AGENTS.md) |
+| `src/hooks/` | Data fetching, SSE, real-time hooks | [AGENTS.md](src/hooks/AGENTS.md) |
+| `src/app/` | Next.js routes (dashboard, showcase, API) | [AGENTS.md](src/app/AGENTS.md) |
+| `src/mcp/` | MCP server for AI agents (Nasra tools) | [AGENTS.md](src/mcp/AGENTS.md) |
+| `src/types/` | TypeScript types (config, AI, blocks) | [AGENTS.md](src/types/AGENTS.md) |
+| `packages/core/` | @convergio/core npm package (re-exports) | [AGENTS.md](packages/core/AGENTS.md) |
 
-**Maranello** is the name of the design system — the 103 components with the `Mn` prefix. It lives *inside* Convergio.
+## Rules (apply everywhere)
 
-### Two Usage Modes
+1. **No hardcoded colors** — `var(--mn-*)` tokens only
+2. **4 themes** — navy, dark, light, colorblind. Test all.
+3. **Lucide icons only** — zero emoji
+4. **250 lines max per file** — split to `.helpers.ts`
+5. **Named exports only** — no `export default`
+6. **TypeScript strict** — no `any`
+7. **WCAG 2.2 AA** — keyboard nav, focus rings, ARIA
+8. **i18n** — `useLocale("ns")` for all UI strings
+9. **Catalog-first** — search `component-catalog-data.ts` before creating UI
 
-> **Important:** `convergio-design` (the lower-level design system repo) has been **archived**. All development now happens in `convergio-frontend`. Use this repo for both framework mode and registry mode.
-
-| Mode | When to use | What you do |
-|---|---|---|
-| **Framework mode** | Building a new dashboard/app from scratch | Clone this repo, edit `maranello.yaml`, run `pnpm dev`. You get a full app with zero custom code. Add custom pages in `src/app/(dashboard)/` when YAML blocks aren't enough. |
-| **Registry mode** | Adding components to an existing project | Run `npx shadcn add mn-gauge --registry https://host/r` to copy individual component source into your project. You only get the component, not the framework. |
-
-**Framework mode is the primary use case.** If someone asks you to "use Convergio" or "build with Maranello", they almost certainly mean framework mode.
-
----
-
-## Mental Model
-
-```
-maranello.yaml
-      |
-      v
-config-loader.ts ──> Zod validation (config-schema.ts)
-      |
-      ├──> loadAppConfig()    ──> app-shell.tsx (brand name, logo)
-      ├──> loadNavSections()  ──> sidebar.tsx (navigation sections)
-      ├──> loadPageConfig()   ──> page-renderer.tsx (block grid)
-      ├──> loadAIConfig()     ──> ai-chat-panel (agents, models)
-      └──> loadLocaleOverrides() ──> MnLocaleProvider (i18n)
-```
-
-**The YAML is the single source of truth.** When a user edits `maranello.yaml` (or `convergio.yaml`) and restarts the dev server, the entire app updates: branding, sidebar navigation, page layouts, AI agents — everything.
-
-Config file resolution (first match wins):
-1. `$MARANELLO_CONFIG_PATH` env var
-2. `$CONVERGIO_CONFIG_PATH` env var
-3. `./maranello.yaml` in project root
-4. `./convergio.yaml` in project root
-
----
-
-## Key Files You Must Know
-
-| File | Purpose |
-|---|---|
-| `maranello.yaml` / `convergio.yaml` | App configuration: branding, theme, navigation, pages, AI agents |
-| `src/lib/config-loader.ts` | Parses YAML, validates with Zod, caches, watches for changes in dev |
-| `src/lib/config-schema.ts` | Zod schema for the config file structure |
-| `src/lib/config-block-schemas.ts` | Zod schemas for each page block type (discriminated union on `type`) |
-| `src/components/page-renderer.tsx` | Maps block `type` values to React components |
-| `src/components/shell/` | App shell: sidebar, header, breadcrumbs, search combobox |
-| `src/app/(dashboard)/layout.tsx` | Dashboard layout — calls `loadAppConfig()` + `loadNavSections()` |
-| `src/app/(dashboard)/[...slug]/page.tsx` | Catch-all route for YAML-defined pages |
-| `src/components/maranello/index.ts` | Barrel export for all 103 Maranello components |
-| `src/app/globals.css` | Theme tokens: `--mn-*` CSS custom properties for all 4 themes |
-| `CLAUDE.md` | AI-first component selection rules and page composition patterns |
-| `CONSTITUTION.md` | Binding code rules (accessibility, themes, naming, file size limits) |
-| `src/lib/component-catalog-data.ts` | 103-entry searchable catalog — search before creating any UI |
-| `src/lib/api-night-agents.ts` | Typed HTTP client for night-agents daemon API |
-| `src/lib/i18n/` | i18n system: `MnLocaleProvider`, `useLocale()`, `resolveLocale()`, English defaults |
-
-### Specialist Agents
-
-Four specialist agents have deep domain knowledge. Use their files for context when working in their domain:
-
-| Agent | File | Domain |
-|---|---|---|
-| **Nasra** | `AGENT-NASRA.md` | Data visualization, charts, gauges, real-time streaming, monitoring |
-| **Jony** | `AGENT-JONY.md` | CRUD pages, data tables, forms, modals, detail panels |
-| **Baccio** | `AGENT-BACCIO.md` | Testing, accessibility, responsive design, quality gates |
-| **Sara** | `AGENT-SARA-UX.md` | Page composition, API integration, data mapping, UX patterns |
-
----
-
-## How to Add a Dashboard Page (YAML Only)
-
-Add a route entry under `pages:` in your YAML config:
-
-```yaml
-pages:
-  /analytics:
-    title: Analytics
-    rows:
-      - columns: 3
-        blocks:
-          - { type: kpi-card, label: Users, value: "12,345", change: "+5%", trend: up }
-          - { type: kpi-card, label: Revenue, value: "$890K", change: "+12%", trend: up }
-          - { type: kpi-card, label: Churn, value: "2.1%", change: "-0.3%", trend: down }
-      - columns: 2
-        blocks:
-          - type: chart-block
-            chartType: area
-            labels: [Jan, Feb, Mar, Apr, May]
-            series:
-              - { label: Growth, data: [100, 120, 115, 140, 160] }
-          - type: gauge-block
-            label: Health Score
-            value: 87
-            min: 0
-            max: 100
-            unit: "%"
-```
-
-Then add it to navigation:
-
-```yaml
-navigation:
-  sections:
-    - label: Main
-      items:
-        - { id: analytics, label: Analytics, href: /analytics, icon: BarChart3 }
-```
-
-No code changes needed. Restart the dev server.
-
-### Available Block Types
-
-`kpi-card` | `data-table` | `data-table-maranello` | `activity-feed` | `stat-list` | `empty-state` | `ai-chat` | `gauge-block` | `chart-block` (sparkline/donut/area/bar/radar/bubble) | `funnel-block` | `hbar-block` | `speedometer-block` | `gantt-block` | `kanban-block` | `okr-block` | `map-block` | `system-status-block` | `workflow-orchestrator-block`
-
----
-
-## How to Add a Custom Page (React)
-
-When YAML blocks aren't enough, create a Next.js page inside the dashboard group:
-
-```
-src/app/(dashboard)/your-page/page.tsx
-```
-
-It automatically inherits the sidebar, header, breadcrumbs, and theme from the `(dashboard)` layout. Import components from the barrel:
-
-```tsx
-import { MnChart, MnDataTable, MnBadge } from "@/components/maranello";
-```
-
-Then add a navigation entry in your YAML config to make it appear in the sidebar.
-
----
-
-## How to Create a New Maranello Component
-
-Follow `docs/guides/creating-a-component.md`. Summary:
-
-1. **File:** `src/components/maranello/{category}/mn-your-component.tsx`
-2. **Prefix:** always `Mn` (e.g., `MnYourComponent`)
-3. **Export:** named only, never default
-4. **Pattern:** CVA + cn() for variants, `"use client"` only if hooks are used
-5. **Colors:** CSS custom properties (`--mn-*`), never hardcoded hex
-6. **Max size:** 250 lines — extract logic to `mn-your-component.helpers.ts`
-7. **Barrel:** add to `src/components/maranello/index.ts`
-8. **Registry:** add JSON to `public/r/` for shadcn CLI installation
-
-Categories: `agentic` | `data-display` | `data-viz` | `feedback` | `financial` | `forms` | `layout` | `navigation` | `network` | `ops` | `strategy` | `theme`
-
----
-
-## Code Conventions (CONSTITUTION.md)
-
-These are **non-negotiable**. Violations will be rejected in review.
-
-| Rule | Requirement |
-|---|---|
-| TypeScript strict | No `any` type, ever |
-| Named exports only | No `export default` |
-| No hardcoded colors | Use `--mn-*` CSS custom properties |
-| 4 themes always | Every component must work in navy, dark, light, colorblind |
-| Max 250 lines/file | Split logic into `.helpers.ts` sibling files |
-| Lucide icons only | Zero emoji anywhere (P2) |
-| `"use client"` | Only on files that use React hooks |
-| WCAG 2.2 AA | Minimum accessibility level for all components |
-| Keyboard-first | All interactive elements must be keyboard-navigable |
-| No `<table>` elements | Use `MnDataTable` for ALL tabular data (P9) |
-| No custom metric cards | Use `MnDashboardStrip` or `MnKpiScorecard` (P10) |
-| No hardcoded hex in JSX | Use `var(--mn-*)` tokens only (P11) |
-| Catalog-first | Search `component-catalog-data.ts` before creating any UI (P12) |
-| English only | All code, comments, and documentation in English |
-| i18n-ready | All user-facing strings via `useLocale()` — no hardcoded English in JSX |
-
----
-
-## Theme System
-
-4 themes, switched via `data-theme` attribute on `<html>`:
-
-| Theme | Key | Colors |
-|---|---|---|
-| Navy | `navy` | Deep blue bg `#0d2045`, gold accent `#FFC72C` |
-| Dark | `dark` | Near-black bg `#111111`, gold accent `#FFC72C` |
-| Light | `light` | Warm ivory bg `#FAF3E6`, red accent `#DC0000` |
-| Colorblind | `colorblind` | Dark bg `#111111`, blue accent `#0072B2` (Okabe-Ito) |
-
-Components read colors via:
-- CSS custom properties: `var(--mn-surface)`, `var(--mn-accent)`, etc.
-- Canvas components: `readPalette(el)` reads `getComputedStyle()` + `data-theme`
-- Never hardcode hex values in components
-
----
-
-## API Integration
-
-| Hook | Purpose | File |
-|---|---|---|
-| `useApiQuery` | SWR-like poller with `pollInterval`, error handling, `refetch()` | `src/hooks/use-api-query.ts` |
-| `useEventSource` | SSE stream with auto-reconnect + exponential backoff | `src/hooks/use-event-source.ts` |
-| `useSSEAdapter` | Generic SSE adapter — reducer-based state accumulation over `useEventSource` | `src/hooks/use-sse-adapter.ts` |
-| `useBrain3DLive` | SSE → Brain3D nodes/edges (convenience wrapper) | `src/hooks/use-sse-adapter.convenience.ts` |
-| `useAgentTraceLive` | SSE → AgentTrace steps (convenience wrapper) | `src/hooks/use-sse-adapter.convenience.ts` |
-| `useHubSpokeLive` | SSE → HubSpoke hub/spokes (convenience wrapper) | `src/hooks/use-sse-adapter.convenience.ts` |
-| `useApprovalChainLive` | SSE → ApprovalChain steps (convenience wrapper) | `src/hooks/use-sse-adapter.convenience.ts` |
-| `useActiveMissionsLive` | SSE → ActiveMissions missions (convenience wrapper) | `src/hooks/use-sse-adapter.convenience.ts` |
-
-Backend URL comes from `src/lib/env.ts`:
-- Server: `API_URL` env var (default `http://localhost:8420`)
-- Client: `NEXT_PUBLIC_API_URL` env var
-
----
-
-## Build & Test Commands
+## Build commands
 
 ```bash
-pnpm dev          # dev server at http://localhost:3000
-pnpm build        # production build
-pnpm lint         # ESLint
-pnpm typecheck    # TypeScript strict check
-pnpm test         # unit tests (Vitest)
-pnpm test:e2e     # Playwright E2E
+pnpm dev        # http://localhost:3000
+pnpm build      # production build
+pnpm lint       # ESLint
+pnpm typecheck  # tsc --noEmit
+pnpm test       # Vitest
+pnpm test:e2e   # Playwright
+pnpm mcp        # MCP server
 ```
-
----
-
-## Common Mistakes to Avoid
-
-1. **Treating this as a component library** — it's a full framework. Clone and configure, don't try to `npm install` it.
-2. **Hardcoding colors** — use `--mn-*` CSS custom properties. The 4-theme system will break otherwise.
-3. **Using `export default`** — the codebase uses named exports exclusively.
-4. **Using emoji** — Lucide icons only (CONSTITUTION P2).
-5. **Ignoring the YAML** — check `maranello.yaml`/`convergio.yaml` before writing code. Many features are config-driven.
-6. **Creating files > 250 lines** — split into component + `.helpers.ts`.
-7. **Using `any`** — TypeScript strict mode, no exceptions.
-8. **Forgetting themes** — test every visual change in all 4 themes.
-9. **Using `<table>` or custom grids** — always use `MnDataTable` for tabular data (P9).
-10. **Creating custom metric cards** — use `MnDashboardStrip` or `MnKpiScorecard` (P10).
-11. **Skipping catalog search** — always check `component-catalog-data.ts` before creating any UI element (P12).
-12. **Using `Sheet`/`Dialog` for detail views** — use `MnDetailPanel` instead. See `docs/guides/common-mistakes.md`.
-13. **Hardcoding English strings** — use `useLocale("namespace")` for client components or `resolveLocale("namespace")` for server components. See `docs/guides/i18n.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,157 +1,51 @@
-# Maranello Design System — AI Instructions
+# Convergio UI Framework — AI Instructions
 
-## Core Rules (NON-NEGOTIABLE)
-1. **CONSTITUTION P2**: Zero emoji in JSX — Lucide SVG icons ONLY
-2. **No custom UI**: Search `component-catalog-data.ts` BEFORE writing any component
-3. **No hardcoded colors**: Use `var(--mn-*)` tokens exclusively
-4. **No raw HTML elements**: Use Maranello components for tables, forms, panels, charts
-5. **No hardcoded English**: Use `useLocale("ns")` for UI strings — see `src/lib/i18n/`
+## Quick start
+Read `AGENTS.md` for project overview. Each `src/` subdirectory has its own `AGENTS.md`.
 
-## Component Selection — MANDATORY lookup
-Before creating ANY UI element, search the catalog by intent:
+## Rules (NON-NEGOTIABLE)
+1. **No hardcoded colors** — `var(--mn-*)` tokens only
+2. **4 themes** — navy, dark, light, colorblind. Test all.
+3. **Lucide icons only** — zero emoji (CONSTITUTION P2)
+4. **250 lines max per file** — split to `.helpers.ts`
+5. **Named exports only** — no `export default`
+6. **TypeScript strict** — no `any`
+7. **WCAG 2.2 AA** — keyboard nav, focus rings, ARIA
+8. **i18n** — `useLocale("ns")` for all UI strings, no hardcoded English
+9. **Catalog-first** — search `src/lib/component-catalog-data.ts` before creating UI
+10. **No raw HTML tables** — use `MnDataTable`
+11. **No custom metric cards** — use `MnDashboardStrip` or `MnKpiScorecard`
 
-| Need | Use | NOT |
-|------|-----|-----|
-| KPI metrics strip | `MnDashboardStrip` | Custom divs with numbers |
-| Data table | `MnDataTable` | `<table>` or custom grid |
-| Side detail panel | `MnDetailPanel` | Sheet, Dialog, custom sidebar |
-| Horizontal bars | `MnHbar` | Custom div bars |
-| Vertical bar/line/area chart | `MnChart` | recharts/chart.js direct |
-| Funnel visualization | `MnFunnel` (large) or `MnHbar` (compact) | Custom SVG |
-| Gauge/meter | `MnGauge`, `MnHalfGauge`, `MnSpeedometer` | Custom SVG circles |
-| Progress | `MnProgressRing` | Custom progress bars |
-| Heatmap | `MnHeatmap` | Custom table with colors |
-| Gantt timeline | `MnGantt` | Custom timeline divs |
-| Status indicator | `MnBadge` | Colored spans |
-| Loading state | `MnStateScaffold` | Custom loading spinners |
-| Card container | `MnSectionCard` | Custom bordered divs |
-| Filter panel | `MnFilterPanel` or `MnFacetWorkbench` | Custom select dropdowns |
-| Tab navigation | `MnTabs` | Custom tab divs |
-| Form fields | `MnFormField` | Raw input elements |
-| Search | `MnSearchDrawer` or `MnCommandPalette` | Custom search inputs |
-| Kanban | `MnKanbanBoard` | Custom column layout |
-| Animated numbers | `MnFlipCounter` | Static number display |
-| Dashboard layout | `MnDashboard` or `MnGridLayout` | Custom flex/grid divs |
-| Icon | Lucide React import | Emoji, Unicode symbols, custom SVG |
-| KPI scorecard | `MnKpiScorecard` | Custom metric cards |
-| OKR tracker | `MnOkr` | Custom objective lists |
-| Risk matrix | `MnRiskMatrix` | Custom colored grids |
-| Decision matrix | `MnDecisionMatrix` | Custom scoring tables |
-| Org chart | `MnOrgChart` | Custom nested divs |
-| Activity feed | `MnActivityFeed` | Custom event lists |
-| Modal | `MnModal` | Raw dialog element |
-| Toast | `MnToast` | Custom alert divs |
-| Stepper/wizard | `MnStepper` | Custom step indicators |
-| Process/workflow timeline | `MnProcessTimeline` | Custom timeline divs |
-| Workflow orchestration | `MnWorkflowOrchestrator` | Custom SVG/canvas graphs |
-| Breadcrumb | `MnBreadcrumb` | Custom path links |
+## Component lookup
+Search `src/lib/component-catalog-data.ts` by keyword. Read the `whenToUse` field.
+Or use the MCP server: `pnpm mcp` → `search_components` tool.
 
-## How to find the right component
-1. Open `src/lib/component-catalog-data.ts`
-2. Search by keyword (supports EN and IT): e.g., "table", "chart", "gauge"
-3. Read the `whenToUse` field — it tells you exactly when to use it
-4. Read the component's `.tsx` file to understand its props interface
-5. NEVER create a custom component when a Maranello one exists
-
-## Color Tokens (never use hex literals)
-```css
-/* Accent */
-var(--mn-accent)           /* Primary action color */
-var(--mn-accent-hover)     /* Hover state */
-var(--mn-accent-text)      /* Text on accent */
-var(--mn-accent-bg)        /* Subtle accent background */
-var(--mn-accent-border)    /* Accent-tinted border */
-
-/* Status */
-var(--mn-success)          /* Green — positive */
-var(--mn-success-bg)       /* Success background */
-var(--mn-warning)          /* Yellow — caution */
-var(--mn-warning-bg)       /* Warning background */
-var(--mn-error)            /* Red — danger */
-var(--mn-error-bg)         /* Error background */
-var(--mn-info)             /* Blue — informational */
-var(--mn-info-bg)          /* Info background */
-
-/* Text */
-var(--mn-text)             /* Primary text */
-var(--mn-text-muted)       /* Secondary text */
-var(--mn-text-tertiary)    /* Tertiary text */
-var(--mn-text-disabled)    /* Disabled text */
-var(--mn-text-inverse)     /* Inverse text */
-
-/* Surface */
-var(--mn-surface)          /* Background */
-var(--mn-surface-raised)   /* Elevated surface (cards) */
-var(--mn-surface-sunken)   /* Recessed surface */
-var(--mn-surface-input)    /* Input field background */
-var(--mn-surface-overlay)  /* Overlay/popover background */
-var(--mn-surface-hover)    /* Hover state background */
-
-/* Border */
-var(--mn-border)           /* Default border */
-var(--mn-border-subtle)    /* Subtle separator */
-var(--mn-border-strong)    /* Emphasized border */
-var(--mn-border-focus)     /* Focus ring border */
-
-/* Interactive */
-var(--mn-hover-bg)         /* Hover background */
-var(--mn-active-bg)        /* Active/pressed background */
-var(--mn-focus-ring)       /* Focus ring color */
+## Import convention
+```tsx
+import { MnDataTable, MnBadge } from "@/components/maranello";
+import { useLocale } from "@/lib/i18n";
+import { BarChart3 } from "lucide-react";
+import { cn } from "@/lib/utils";
 ```
 
-## Page Composition Pattern
-Every page should follow this structure:
-1. Import data-fetching functions (API layer)
-2. Import Maranello components (NO custom UI)
-3. Map API data to component props (pure transforms)
-4. Compose components in a layout
+## Color tokens
+```css
+var(--mn-accent)       var(--mn-surface)       var(--mn-text)
+var(--mn-success)      var(--mn-surface-raised) var(--mn-text-muted)
+var(--mn-warning)      var(--mn-surface-sunken) var(--mn-border)
+var(--mn-error)        var(--mn-hover-bg)       var(--mn-focus-ring)
+```
 
+## Page composition
 ```tsx
-// CORRECT — data mapping only, zero custom UI
-export default function DashboardPage() {
+// CORRECT — Maranello components only, data mapping
+export function Page() {
   const data = useApiQuery(() => fetchData());
-  const metrics = buildMetrics(data);     // pure data transform
-  const tableRows = buildRows(data);      // pure data transform
   return (
     <>
-      <MnDashboardStrip metrics={metrics} />
-      <MnDataTable columns={COLS} data={tableRows} />
+      <MnDashboardStrip metrics={buildMetrics(data)} />
+      <MnDataTable columns={COLS} data={buildRows(data)} />
     </>
   );
 }
-
-// WRONG — custom UI elements
-export default function DashboardPage() {
-  return (
-    <div className="grid grid-cols-4 gap-4">
-      <div className="rounded-lg border p-4">  {/* custom card */}
-        <span className="text-2xl font-bold">55</span>
-      </div>
-    </div>
-  );
-}
 ```
-
-## Import Convention
-
-```tsx
-// Maranello components — import from barrel
-import { MnDataTable, MnBadge, MnDashboardStrip } from "@/components/maranello"
-
-// i18n — import from i18n barrel
-import { useLocale } from "@/lib/i18n"
-
-// Icons — import from lucide-react
-import { BarChart3, Users, TrendingUp } from "lucide-react"
-
-// Utils
-import { cn } from "@/lib/utils"
-```
-
-## File Rules
-- Max 250 lines per file (CONSTITUTION P4) — extract to `.helpers.ts` if needed
-- Named exports only — never `export default` for components
-- `"use client"` only when hooks are actually used
-- TypeScript strict — no `any` types
-- All colors via `--mn-*` CSS variables — NEVER hardcoded hex
-- All user-facing strings via `useLocale("namespace")` — NEVER hardcoded English in JSX

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Convergio Frontend Framework
+# Convergio UI Framework
 
-[![Live Demo](https://img.shields.io/badge/Live%20Demo-convergio--frontend.vercel.app-blue)](https://convergio-frontend.vercel.app) [![Showcase](https://img.shields.io/badge/Showcase-Cockpit%20%26%20Components-gold)](https://convergio-frontend.vercel.app/showcase/cockpit)
+[![Live Demo](https://img.shields.io/badge/Live%20Demo-convergio--ui--framework.vercel.app-blue)](https://convergio-ui-framework.vercel.app) [![Showcase](https://img.shields.io/badge/Showcase-Cockpit%20%26%20Components-gold)](https://convergio-ui-framework.vercel.app/showcase/cockpit)
 
-A **config-driven dashboard framework** with 101+ React components, 4 themes, and a shadcn-compatible registry. Write YAML, get a full working app — sidebar, themes, AI chat, data visualizations — with zero custom code.
+A **config-driven dashboard framework** with 103 React components, 4 themes, and a shadcn-compatible registry. Write YAML, get a full working app — sidebar, themes, AI chat, data visualizations — with zero custom code.
 
 **Maranello** is the design system inside Convergio. The framework ships everything: layout shell, theme engine, config loader, page renderer, component showcase, and optional AI/desktop layers.
 
-> **Live demo:** [convergio-frontend.vercel.app](https://convergio-frontend.vercel.app) — explore all components interactively, including the [Cockpit](https://convergio-frontend.vercel.app/showcase/cockpit) with Ferrari Luce-inspired gauges, dashboard strip, and instrument binnacle.
+> **Live demo:** [convergio-ui-framework.vercel.app](https://convergio-ui-framework.vercel.app) — explore all components interactively, including the [Cockpit](https://convergio-ui-framework.vercel.app/showcase/cockpit) with Ferrari Luce-inspired gauges, dashboard strip, and instrument binnacle.
 
 ### Screenshots
 
@@ -22,114 +22,56 @@ A **config-driven dashboard framework** with 101+ React components, 4 themes, an
 |---|---|
 | ![Agentic](docs/screenshots/agentic.png) | ![Data Viz](docs/screenshots/dataviz.png) |
 
-## Two Ways to Use It
+## Three Ways to Use It
 
-> **Note:** The `convergio-design` repo (lower-level design tokens and web components) has been **archived**. For all new projects — whether you want the full framework or individual components — start here with `convergio-frontend`.
+> **Note:** The `convergio-design` repo has been **archived**. Start here for everything.
 
 ### 1. Framework Mode — Clone and Configure (Recommended)
 
 Clone this repo, edit one YAML file, and you have a production-ready dashboard app. No React code required for basic dashboards.
 
 ```bash
-git clone https://github.com/Roberdan/convergio-frontend.git my-app
+git clone https://github.com/Roberdan/convergio-ui-framework.git my-app
 cd my-app
 pnpm install
+pnpm dev    # open http://localhost:3000
 ```
 
-Edit `maranello.yaml` (or `convergio.yaml`) in the project root:
+Edit `maranello.yaml` — branding, navigation, pages, AI agents — all config-driven.
 
-```yaml
-app:
-  name: Acme Dashboard
-  logo: /logo.svg
+### 2. Core Package Mode — Install the Framework Shell
 
-theme:
-  default: dark
-
-navigation:
-  sections:
-    - label: Main
-      items:
-        - { id: home, label: Home, href: /, icon: LayoutDashboard }
-        - { id: team, label: Team, href: /team, icon: Users }
-
-pages:
-  /:
-    title: Home
-    rows:
-      - columns: 3
-        blocks:
-          - { type: kpi-card, label: Revenue, value: "$1.2M", change: "+8%", trend: up }
-          - { type: kpi-card, label: Users, value: "34,521", change: "+12%", trend: up }
-          - { type: kpi-card, label: Uptime, value: "99.97%", trend: flat }
-      - columns: 2
-        blocks:
-          - type: chart-block
-            chartType: area
-            labels: [Jan, Feb, Mar, Apr, May, Jun]
-            series:
-              - { label: Revenue, data: [80, 95, 110, 108, 130, 142] }
-          - type: gauge-block
-            label: CPU Load
-            value: 73
-            min: 0
-            max: 100
-            unit: "%"
-            size: md
-  /team:
-    title: Team
-    rows:
-      - columns: 1
-        blocks:
-          - type: data-table-maranello
-            columns: [{ accessorKey: name, header: Name }, { accessorKey: role, header: Role }]
-            data:
-              - { name: Alice, role: Engineer }
-              - { name: Bob, role: Designer }
-```
+Already have a Next.js project? Install only the framework core (shell, config, theme, hooks) and add the components you need:
 
 ```bash
-pnpm dev    # open http://localhost:3000 — your dashboard is live
+# Install the core framework
+npm install github:Roberdan/convergio-ui-framework#packages/core
+
+# Ask Nasra which components your YAML config needs
+pnpm mcp  # then call: analyze_yaml_needs with your YAML
+
+# Install only those components (shadcn-style, copied to your project)
+npx shadcn add mn-gauge mn-chart mn-data-table --registry https://convergio-ui-framework.vercel.app/r
 ```
 
-**What you get out of the box:**
-- Responsive sidebar navigation (auto-generated from YAML)
-- 4 themes with one-click switching (header dropdown, Cmd-K palette, or Manettino dial)
-- WCAG 2.2 AA accessibility with floating a11y toolbar
-- Command palette (Cmd-K) with fuzzy search across all components
-- Config-driven pages — add new routes by adding entries to `pages:` in YAML
-- Optional AI chat panel, SSE event streams, API polling hooks
+```tsx
+import { AppShell, loadNavSections, PageRenderer } from "@convergio/core";
+import { MnGauge } from "./components/maranello/data-viz/mn-gauge";
+```
 
-### Quick-start presets
+This gives you the shell + config engine without copying all 103 components.
 
-If you want a stronger starting point than a blank dashboard, copy one of the curated presets:
+### 3. Registry Mode — Cherry-Pick Components Only
+
+Just want individual components in an existing project?
 
 ```bash
-cp presets/workspace.yaml convergio.yaml   # SaaS / delivery workbench
-cp presets/ops.yaml convergio.yaml         # incident / control center
-cp presets/executive.yaml convergio.yaml   # leadership / board cockpit
-pnpm dev
+npx shadcn add mn-badge mn-gauge --registry https://convergio-ui-framework.vercel.app/r
 ```
 
-These presets are intentionally opinionated: believable seed data, one primary workflow per surface, and accessibility defaults kept on by design.
+Components are self-contained `.tsx` files copied into your project. Dependencies auto-resolved via `registryDependencies` in each registry JSON.
 
-**What you add when you need it:**
-- Custom React pages in `src/app/(dashboard)/your-page/page.tsx`
-- Custom components in `src/components/maranello/your-category/`
-- API backend connection via `API_URL` env var + `use-api-query` / `use-event-source` hooks
-
-### 2. Registry Mode — Cherry-Pick Components
-
-Already have a Next.js/React project? Install individual Maranello components via the shadcn CLI:
-
-```bash
-npx shadcn add mn-badge --registry https://your-maranello-host/r
-npx shadcn add mn-gauge mn-chart mn-data-table --registry https://your-maranello-host/r
-```
-
-Browse the full registry at `/r/index.json`. Each component JSON includes source code, npm dependencies, and registry dependencies. See `docs/guides/using-the-registry.md` for setup instructions.
-
-> **Note:** Registry mode gives you individual components. Framework mode gives you the complete app shell, config engine, theme system, and all 101 components working together.
+> **Summary:** Framework mode = full app. Core package = shell + pick your components. Registry = components only.
 
 ---
 
@@ -164,7 +106,7 @@ If no config file is found, the framework renders sensible defaults (app name "M
 |---|---|
 | Framework | Next.js 16 App Router |
 | UI Primitives | shadcn/ui + Base UI + Tailwind CSS v4 |
-| Design System | Maranello — 101 components with `Mn` prefix |
+| Design System | Maranello — 103 components with `Mn` prefix |
 | Typography | Outfit (headings), Inter (body), Barlow Condensed (mono/data) |
 | Themes | 4: Navy, Dark, Light, Colorblind (WCAG 2.2 AA) |
 | Icons | Lucide only (no emoji — CONSTITUTION P2) |
@@ -329,7 +271,7 @@ src/
     globals.css             # theme tokens: --mn-* + shadcn bridge vars
     layout.tsx              # root: fonts, theme script, CanvasSafeArc
   components/
-    maranello/              # Maranello Design System — 101 components
+    maranello/              # Maranello Design System — 103 components
       agentic/              #   7 AI/agent components
       data-display/         #  12 data display components
       data-viz/             #  14 data visualization components
@@ -343,7 +285,7 @@ src/
       strategy/             #  11 strategy components
       theme/                #   6 theme control + accessibility components
       shared/               #   shared utilities + tests
-      index.ts              #   barrel re-export (all 101 components)
+      index.ts              #   barrel re-export (all 103 components)
     blocks/                 # page blocks — renders config → UI
     page-renderer.tsx       # renders config pages → block grid
     shell/                  # sidebar, header, command-menu (Cmd-K)
@@ -358,7 +300,7 @@ src/
     config-loader.ts        # YAML parser + Zod validation (cached, file-watched in dev)
     config-schema.ts        # Zod schema for config file
     config-block-schemas.ts # Zod schemas for each block type
-    component-catalog.ts    # 101-entry catalog with bilingual search
+    component-catalog.ts    # 103-entry catalog with bilingual search
     env.ts                  # environment variable resolution
     icon-map.ts             # Lucide icon name → component resolver
     icon-slot.tsx           # <IconSlot name="..." /> for dynamic icons
@@ -367,7 +309,7 @@ src/
 src-tauri/                  # optional Tauri desktop scaffold
 docs/
   guides/                   # how-to guides (see Documentation section)
-  components/               # per-component MDX docs (101 files)
+  components/               # per-component MDX docs (103 files)
   adr/                      # architecture decision records
 ```
 
@@ -418,13 +360,13 @@ The built-in showcase at `/showcase` demonstrates all components with live inter
 ### Command Palette (Cmd-K)
 
 Press `Cmd+K` (or `Ctrl+K`) to open the command palette:
-- **Fuzzy search** across all 101 components (bilingual IT/EN keywords)
+- **Fuzzy search** across all 103 components (bilingual IT/EN keywords)
 - **Category navigation** — jump to any showcase section
 - **Theme switching** — switch between all 4 themes
 
 ## MCP Server (AI Agent Integration)
 
-The framework includes a built-in [Model Context Protocol](https://modelcontextprotocol.io) server that lets AI agents discover components, generate YAML configs, and get composition advice.
+Built-in [Model Context Protocol](https://modelcontextprotocol.io) server — 10 tools for AI agents.
 
 ```bash
 pnpm mcp   # starts the MCP server (stdio transport)
@@ -434,13 +376,16 @@ pnpm mcp   # starts the MCP server (stdio transport)
 
 | Tool | Description |
 |---|---|
-| `search_components` | Fuzzy search the 101+ component catalog by name, category, or keyword |
+| `search_components` | Fuzzy search the 103 component catalog by name, category, or keyword |
 | `get_component` | Full details: props, when-to-use, code example, file path |
 | `list_categories` | All categories with component counts |
 | `generate_yaml_page` | Generate valid YAML page config from a description |
 | `list_block_types` | Available YAML block types with descriptions |
 | `get_composition` | Recommended component combinations for a use-case |
 | `get_theme_tokens` | Theme color tokens for all 4 themes |
+| `analyze_yaml_needs` | Parse a YAML config and list which components are needed |
+| `resolve_component_deps` | Resolve transitive dependencies for a list of components |
+| `install_components` | Generate shadcn install command with all resolved deps |
 
 ### Configure in your MCP client
 
@@ -451,7 +396,7 @@ pnpm mcp   # starts the MCP server (stdio transport)
     "convergio": {
       "command": "npx",
       "args": ["tsx", "src/mcp/server.ts"],
-      "cwd": "/path/to/convergio-frontend"
+      "cwd": "/path/to/convergio-ui-framework"
     }
   }
 }
@@ -476,7 +421,7 @@ The `public/r/` directory contains a shadcn-compatible component registry:
 
 ```
 public/r/
-  index.json              # full catalog with metadata for all 101 components
+  index.json              # full catalog with metadata for all 103 components
   mn-badge.json           # individual component (source + dependencies)
   mn-gauge.json
   ...
@@ -546,7 +491,7 @@ import { MnLocaleProvider } from "@/lib/i18n";
 
 ---
 
-## Component Catalog (101 components)
+## Component Catalog (103 components)
 
 ```tsx
 import { MnBadge, MnChart, MnDataTable, MnGauge } from "@/components/maranello"

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,0 +1,22 @@
+# @convergio/core
+
+NPM package re-exporting framework essentials from `src/`.
+
+| Subpath | Exports |
+|---------|---------|
+| `@convergio/core` | Everything (barrel) |
+| `@convergio/core/shell` | AppShell, Sidebar, Header, SearchCombobox |
+| `@convergio/core/config` | loadAppConfig, loadNavSections, schemas |
+| `@convergio/core/theme` | ThemeProvider, ThemeSwitcher, ThemeScript |
+| `@convergio/core/hooks` | useApiQuery, useSSEAdapter, 5 convenience hooks |
+| `@convergio/core/blocks` | KpiCard, DataTable, ActivityFeed, StatList, EmptyState, AIChatPanel |
+| `@convergio/core/block-registry` | registerBlock, lazyBlock, getBlock |
+| `@convergio/core/page-renderer` | PageRenderer |
+
+## Consumer usage
+```ts
+import { AppShell, loadNavSections } from "@convergio/core";
+import { MnGauge } from "./components/maranello/data-viz/mn-gauge"; // installed via shadcn
+```
+
+This package has zero own code — it re-exports from `../../src/` via tsconfig path aliases.

--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -1,0 +1,16 @@
+# App Routes
+
+Next.js App Router layout.
+
+| Route | What |
+|-------|------|
+| `(dashboard)/layout.tsx` | Dashboard layout — loads config, renders AppShell, imports block registrations |
+| `(dashboard)/[...slug]/page.tsx` | Catch-all for YAML-defined pages (uses PageRenderer) |
+| `(dashboard)/showcase/` | Component showcase (all 103 Maranello components) |
+| `(dashboard)/dashboard/` | Main dashboard page |
+| `api/chat/route.ts` | AI chat endpoint — 5 providers (openai, azure, anthropic, copilot, qwen) |
+| `api/health/route.ts` | Health check endpoint |
+
+## Adding a page
+1. **YAML-only**: Add under `pages:` in maranello.yaml + navigation entry
+2. **Custom React**: Create `src/app/(dashboard)/your-page/page.tsx` — inherits shell automatically

--- a/src/components/blocks/AGENTS.md
+++ b/src/components/blocks/AGENTS.md
@@ -1,0 +1,14 @@
+# Block Components
+
+Built-in page blocks used by the PageRenderer. These are NOT Maranello components — they are simpler, always-available blocks for YAML-driven pages.
+
+| Block | Type in YAML | What |
+|-------|-------------|------|
+| `kpi-card` | `kpi-card` | Single metric with label, value, change, trend |
+| `data-table` | `data-table` | Simple table with columns and rows |
+| `activity-feed` | `activity-feed` | Chronological event list |
+| `stat-list` | `stat-list` | Key-value stat pairs |
+| `empty-state` | `empty-state` | Placeholder when no data |
+| `ai-chat-panel` | `ai-chat` | AI chat interface (connects to /api/chat) |
+
+Maranello block types (gauge-block, chart-block, etc.) are registered dynamically via `src/lib/block-registry.ts`.

--- a/src/components/maranello/AGENTS.md
+++ b/src/components/maranello/AGENTS.md
@@ -1,0 +1,34 @@
+# Maranello Components
+
+103 React components with `Mn` prefix. CVA + cn() for variants. `"use client"` only if hooks used.
+
+## Categories
+
+| Dir | Count | Domain | Specialist |
+|-----|-------|--------|-----------|
+| `agentic/` | 14 | Agent traces, brain3d, workflows, missions | Nasra |
+| `data-display/` | 12 | Tables, avatars, badges, feeds, detail panels | Jony |
+| `data-viz/` | 14 | Charts, gauges, funnels, heatmaps, speedometers | Nasra |
+| `feedback/` | 6 | Toasts, modals, spinners, state scaffolds | Baccio |
+| `financial/` | 2 | FinOps, cost breakdown | Nasra |
+| `forms/` | 11 | Form fields, selects, date pickers, profiles | Jony |
+| `layout/` | 8 | Dashboards, grids, section cards, panels | Sara |
+| `navigation/` | 5 | Breadcrumbs, tabs, section nav, command palette | Sara |
+| `network/` | 10 | Mesh network, maps, system status, org charts | Nasra |
+| `ops/` | 8 | Gantt, kanban, deployment tables, night jobs | Jony |
+| `shared/` | 2 | Format helpers, test utilities | — |
+| `strategy/` | 11 | OKR, SWOT, risk matrix, BCG, porter, canvas | Sara |
+| `theme/` | 6 | A11y fab, theme toggle/rotary, design tokens | Baccio |
+
+## Creating a component
+
+1. File: `{category}/mn-your-component.tsx`
+2. Prefix: `Mn` (e.g. `MnYourComponent`)
+3. Export: named only, add to `index.ts` barrel
+4. Colors: `var(--mn-*)` tokens, never hex
+5. Max 250 lines — extract to `.helpers.ts`
+6. Registry: add JSON to `public/r/` for shadcn install
+
+## Finding the right component
+
+Search `src/lib/component-catalog-data.ts` by keyword. Read `whenToUse` field.

--- a/src/components/shell/AGENTS.md
+++ b/src/components/shell/AGENTS.md
@@ -1,0 +1,16 @@
+# Shell Components
+
+App shell — the outermost layout wrapper.
+
+| File | What |
+|------|------|
+| `app-shell.tsx` | Main layout: sidebar + header + content. Accepts `a11ySlot` prop. |
+| `sidebar.tsx` | Collapsible sidebar with nav sections. Reads from `loadNavSections()`. |
+| `header.tsx` | Top bar with menu toggle + breadcrumb. |
+| `search-combobox.tsx` | Cmd+K fuzzy search across component catalog. |
+| `sidebar-nav.tsx` | Nav item rendering with active state + icons. |
+
+## Rules
+- Shell must work with **zero Maranello components** installed.
+- All navigation data comes from `maranello.yaml` via config-loader.
+- `AppShell` is a `"use client"` component (uses `useState`, `usePathname`).

--- a/src/hooks/AGENTS.md
+++ b/src/hooks/AGENTS.md
@@ -1,0 +1,14 @@
+# Hooks
+
+| Hook | What | Use when |
+|------|------|----------|
+| `useApiQuery` | SWR-like poller with `pollInterval` | Fetching REST data |
+| `useEventSource` | SSE stream with auto-reconnect | Raw SSE consumption |
+| `useSSEAdapter` | Reducer-based SSE state accumulation | Typed SSE → state |
+| `useBrain3DLive` | SSE → Brain3D nodes/edges | 3D network viz |
+| `useAgentTraceLive` | SSE → AgentTrace steps | Agent activity trace |
+| `useHubSpokeLive` | SSE → HubSpoke hub/spokes | Hub-spoke topology |
+| `useApprovalChainLive` | SSE → ApprovalChain steps | Approval workflows |
+| `useActiveMissionsLive` | SSE → ActiveMissions missions | Mission monitoring |
+
+Backend URL from `src/lib/env.ts`: server=`API_URL`, client=`NEXT_PUBLIC_API_URL`.

--- a/src/lib/AGENTS.md
+++ b/src/lib/AGENTS.md
@@ -1,0 +1,20 @@
+# Lib — Framework Core Logic
+
+| File | What | Used by |
+|------|------|---------|
+| `config-loader.ts` | Parses maranello.yaml, validates with Zod, caches | Layout, shell, pages |
+| `config-schema.ts` | Zod schema for the config file | config-loader |
+| `config-block-schemas.ts` | Zod schemas for each page block type | config-loader |
+| `block-registry.ts` | Dynamic component registry for PageRenderer | page-renderer, blocks |
+| `block-registrations.ts` | Registers all built-in block types (lazy) | Dashboard layout |
+| `component-catalog-data.ts` | 103-entry searchable catalog | MCP tools, search |
+| `icon-map.ts` | Lucide icon name → component resolver | Sidebar, nav |
+| `i18n/` | Locale provider, useLocale(), 80+ namespaces | All components |
+| `utils.ts` | `cn()` class merger (clsx + tailwind-merge) | All components |
+| `env.ts` | API_URL env var validation | API client |
+| `session.ts` | Cookie signing/verification | Auth routes |
+
+## Key patterns
+- Config file resolution: `$MARANELLO_CONFIG_PATH` > `./maranello.yaml` > `./convergio.yaml`
+- Block registry: `registerBlock(type, component)` — lazy loaded via `React.lazy()`
+- i18n: `useLocale("namespace")` for client, `resolveLocale("namespace")` for server

--- a/src/mcp/AGENTS.md
+++ b/src/mcp/AGENTS.md
@@ -1,0 +1,22 @@
+# MCP Server — Nasra Agent Tools
+
+10 tools exposed via Model Context Protocol for AI agent integration.
+
+| Tool | What |
+|------|------|
+| `search_components` | Fuzzy search catalog by keyword (EN/IT) |
+| `get_component` | Get full details for a component by slug |
+| `list_categories` | List all component categories |
+| `list_block_types` | List available YAML block types |
+| `generate_yaml_page` | Generate YAML page from natural language |
+| `get_composition` | Get prebuilt component combos for use-cases |
+| `get_theme_tokens` | Get CSS custom property names and values |
+| `analyze_yaml_needs` | Parse YAML config → list required components |
+| `resolve_component_deps` | Resolve transitive component dependencies |
+| `install_components` | Generate shadcn install command with deps |
+
+## Running
+```bash
+pnpm mcp              # stdio transport
+npx tsx src/mcp/server.ts --http  # HTTP transport
+```

--- a/src/types/AGENTS.md
+++ b/src/types/AGENTS.md
@@ -1,0 +1,8 @@
+# Types
+
+| File | What |
+|------|------|
+| `index.ts` | Re-exports all types (PageConfig, PageBlock, NavItem, etc.) |
+| `config.ts` | PageConfig, PageRow, PageBlock, block type unions |
+| `ai.ts` | AgentConfig, AIConfig — providers: openai, azure, anthropic, copilot, qwen, custom |
+| `night-agents.ts` | Night agent daemon types (definitions, runs, projects) |


### PR DESCRIPTION
## What
Restructure all agent documentation for better discoverability.

### Before (1059 lines, heavy overlap)
- 7 root-level files with same rules copied 4x
- Agent entering `src/hooks/` had to read 1000 lines of root docs to find hook info

### After (397 lines, zero overlap)
- `AGENTS.md` in every `src/` subdirectory (9 files) — local context on entry
- Root docs slimmed: CLAUDE.md 157→51, AGENTS.md 252→41
- Rules written once, referenced everywhere

### README updates
- `convergio-frontend` → `convergio-ui-framework` everywhere
- 101 → 103 components
- 'Two Ways to Use It' → **'Three Ways'** (adds Core Package Mode)
- MCP tools: 7 → 10 (new: analyze_yaml_needs, resolve_component_deps, install_components)

### New per-folder AGENTS.md
| File | Lines | Covers |
|------|-------|--------|
| `src/components/maranello/AGENTS.md` | 34 | 103 components, 13 categories, how to create |
| `src/components/shell/AGENTS.md` | 16 | App shell, sidebar, header |
| `src/components/blocks/AGENTS.md` | 14 | 6 built-in block types |
| `src/lib/AGENTS.md` | 20 | Config, registry, i18n, utils |
| `src/hooks/AGENTS.md` | 14 | 8 hooks (API, SSE, convenience) |
| `src/app/AGENTS.md` | 16 | Routes, how to add pages |
| `src/mcp/AGENTS.md` | 22 | 10 MCP tools |
| `src/types/AGENTS.md` | 8 | Type files |
| `packages/core/AGENTS.md` | 22 | @convergio/core exports |