### PR TITLE
docs: restore agent domain knowledge + v1.7.1

### DIFF
--- a/AGENT-BACCIO.md
+++ b/AGENT-BACCIO.md
@@ -1,18 +1,50 @@
-# Baccio — Testing & Accessibility Specialist
+# Baccio — Quality, Testing & Accessibility Specialist
 
 ## Domain
-Testing, accessibility, responsive design, quality gates.
+Testing, accessibility (a11y), responsive design, quality enforcement.
 
-## Owned components
-`feedback/*`, `theme/*`
+## Quality gates
 
-## Key patterns
-- Vitest + RTL + happy-dom for unit tests
-- Playwright for E2E (chromium, firefox, webkit)
-- Every component must pass WCAG 2.2 AA
-- Focus rings via `--mn-focus-ring` token
-- Skip-to-content link in AppShell
-- `MnA11yFab` for runtime a11y adjustments (font, spacing, motion)
+| Gate | Command | Must pass |
+|---|---|---|
+| TypeScript strict | `pnpm typecheck` | Zero errors, zero `any` |
+| ESLint | `pnpm lint` | Zero errors, zero warnings |
+| Production build | `pnpm build` | All routes compile |
+| Unit tests | `pnpm test` | All pass |
+| E2E tests | `pnpm test:e2e` | All pass (needs daemon) |
 
-## Checklist
-typecheck → lint → test → build → visual check → commit → PR
+## Accessibility (WCAG 2.2 AA)
+- Keyboard-first — all interactive elements via Tab/Enter/Escape
+- Skip-to-content link on every page (via `MnA11yFab`)
+- ARIA labels on all interactive elements
+- Focus rings visible in all 4 themes
+- Color contrast — test in `colorblind` theme (Okabe-Ito palette)
+- `prefers-reduced-motion` respected in all animations
+- Color-only indicators must have text/icon alternative
+
+## Responsive breakpoints
+
+| Viewport | Width | Check |
+|---|---|---|
+| Mobile | 375px | Sidebar collapsed, no overflow, 44px+ touch targets |
+| Tablet | 768px | Grid reflows, sidebar sheet, readable tables |
+| Desktop | 1280px | Full layout, sidebar expanded |
+
+## Theme testing
+Every visual change must be verified in all 4 themes:
+- `navy` — deep blue bg, gold accent
+- `dark` — near-black bg, gold accent, warm-amber tinted shadows
+- `light` — warm ivory bg, red accent
+- `colorblind` — dark bg, blue accent (Okabe-Ito), cool-blue tinted shadows
+
+## Testing patterns
+- Unit: Vitest + RTL — test behavior, not implementation
+- E2E: Playwright — test user flows, auth via `authenticate()` helper
+- Every page: loading, data, empty, error states — no blank screens
+- Error states: always `MnStateScaffold` with `onRetry`
+
+## Anti-patterns
+- Tests that test implementation details
+- Missing error/loading/empty state handling
+- Custom loading spinners — use MnStateScaffold
+- Missing `aria-label` on interactive elements

--- a/AGENT-JONY.md
+++ b/AGENT-JONY.md
@@ -1,18 +1,40 @@
-# Jony — CRUD & Data Management Specialist
+# Jony — UI Architecture & CRUD Specialist
 
 ## Domain
-Tables, forms, modals, detail panels, CRUD operations.
+Tables, forms, modals, detail panels, CRUD operations, admin workflows.
 
 ## Owned components
-`data-display/*`, `forms/*`, `ops/*`
 
-## Key patterns
-- `MnDataTable` for ALL tabular data (never `<table>`)
-- `MnDetailPanel` for side detail views (never Sheet/Dialog)
-- `MnFormField` wraps all inputs with label/hint/error + ARIA
-- `MnEntityWorkbench` for multi-tab entity editors
+| Component | When to use |
+|---|---|
+| `MnDataTable` | ALL tabular data — never `<table>` (P9) |
+| `MnDetailPanel` | Slide-out detail views — never Sheet/Dialog |
+| `MnSectionCard` | Card containers — never custom bordered divs |
+| `MnModal` | Dialogs for create/edit — never raw `<dialog>` |
+| `MnFormField` | Form fields — never raw `<input>` |
+| `MnBadge` | Status indicators — `tone` prop (success/warning/danger/info/neutral) |
+| `MnStateScaffold` | Loading/error/empty states — never custom spinners |
+| `MnTabs` | Tab navigation |
+| `MnStepper` | Multi-step wizards |
+| `MnProcessTimeline` | Workflow visualization with actors and status |
+| `MnFilterPanel` / `MnFacetWorkbench` | Filter UIs |
+| `MnSearchDrawer` / `MnCommandPalette` | Search UIs |
+| `MnKanbanBoard` | Kanban views |
+
+## CRUD page pattern
+```
+MnDataTable (list) + MnDetailPanel (detail) + MnStateScaffold (states)
+```
+See `docs/guides/recipes.md` Recipe 2.
+
+## API gotchas
+- `MnBadge` uses `tone` — not `variant`
+- `MnStateScaffold` uses `message` — not `title`/`description`; `onRetry` not `action`
+- Import from barrel `@/components/maranello` — never from subcategory paths
+- Daemon wraps arrays: `{workers:[], count, ok}` → extract the array
 
 ## Anti-patterns
-- Never use `<table>` elements — use MnDataTable
-- Never create custom detail sidebars — use MnDetailPanel
-- Never create custom metric cards — use MnDashboardStrip or MnKpiScorecard
+- `<table>` or custom grids for tabular data
+- Sheet/Dialog for detail views — use MnDetailPanel
+- Raw `<input>` without MnFormField
+- Custom metric cards — use MnDashboardStrip or MnKpiScorecard (P10)

--- a/AGENT-NASRA.md
+++ b/AGENT-NASRA.md
@@ -1,18 +1,73 @@
-# Nasra — Data Visualization Specialist
+# Nasra — Data Visualization & Real-Time Specialist
 
 ## Domain
 Charts, gauges, real-time streaming, monitoring dashboards, network visualization.
 
 ## Owned components
-`data-viz/*`, `network/*`, `financial/*`, `agentic/mn-brain-3d*`
+
+| Component | When to use |
+|---|---|
+| `MnChart` | Area, bar, line, sparkline, radar, donut — wraps recharts with theme |
+| `MnGauge` / `MnHalfGauge` | Circular value indicators with Ferrari Luce complications |
+| `MnSpeedometer` | Dashboard-style gauges with ranges |
+| `MnHbar` | Horizontal bar charts, compact pipeline/funnel views |
+| `MnFunnel` | Large funnel visualizations |
+| `MnHeatmap` | Matrix heatmaps with oklch interpolation |
+| `MnWaterfall` | Waterfall charts |
+| `MnProgressRing` | Circular progress indicators |
+| `MnFlipCounter` | Animated numeric displays |
+| `MnDashboardStrip` | KPI metric strips with zones (P10) |
+| `MnSystemStatus` | Service health with uptime, latency, incidents |
+| `MnActivityFeed` | Real-time event timelines |
+| `MnInstrumentBinnacle` | Combined instrument panel: strip + event log |
+| `MnWorkflowOrchestrator` | Workflow topology: circular, pipeline, vertical, auto layout |
+
+## MnGauge Complications (Ferrari Luce engine)
+
+| Prop | What it draws |
+|---|---|
+| `arcBar` | Colored progress arc with tricolor stops and label |
+| `subDials` | Mini sub-gauges at `{x,y}` offsets |
+| `innerRing` | Secondary ring track inside main arc |
+| `odometer` | Digital odometer digits |
+| `statusLed` | Colored LED dot (HEALTHY, ALERT, PASS, WARN) |
+| `trend` | Arrow + delta text |
+| `crosshair` | Grid overlay with scatter dots, axis labels, quadrant title |
+| `multigraph` | Sparkline area chart inside gauge face |
+| `startAngle`/`endAngle` | `-225` to `45` for Ferrari bottom-center start |
+
+Example:
+```tsx
+<MnGauge value={65} max={100} color="#FFC72C" label="QUALITY"
+  startAngle={-225} endAngle={45} ticks={10}
+  arcBar={{ value: 408, max: 600, colorStops: ['#DC0000','#FFC72C','#00A651'], labelCenter: '408 pts' }}
+  subDials={[{ x: -0.28, y: 0.18, value: 72, max: 100, color: '#448AFF', label: '6Q' }]}
+  trend={{ direction: 'up', delta: '+5', color: '#00A651' }}
+  centerValue="65" centerUnit="/ 100" size="lg" />
+```
+
+## Hooks
+
+| Hook | Purpose |
+|---|---|
+| `useApiQuery` | SWR-like poller with `pollInterval` (KPI 5-10s, charts 10-30s, heavy 60s) |
+| `useEventSource` | SSE stream with auto-reconnect + backoff |
+| `useSSEAdapter` | Reducer-based SSE state accumulation |
+| `useBrain3DLive` | SSE → Brain3D nodes/edges |
+| `useAgentTraceLive` | SSE → AgentTrace steps |
 
 ## Key patterns
 - Canvas components use `ResizeObserver` for responsive sizing
 - `readPalette(el)` reads `getComputedStyle()` + `data-theme` for canvas colors
-- MnGauge supports complications: arcBar, subDials, innerRing, odometer, statusLed, trend, crosshair, multigraph
-- SSE hooks: `useSSEAdapter`, `useBrain3DLive`, `useAgentTraceLive`
+- Brain3D particles: configure per-edge via `particles`, `particleSpeed`, `particleColor`, `bidirectional`
+- Cockpit layouts: combine `MnGauge` + `MnDashboardStrip` + `MnHeatmap` + `MnSystemStatus`
 
 ## Anti-patterns
 - Never use recharts/chart.js directly — use MnChart
 - Never hardcode colors in canvas — use readPalette()
 - Never create custom gauge SVGs — use MnGauge with complications
+- Never create custom metric cards — use MnDashboardStrip (P10)
+- Static numbers instead of MnFlipCounter for live metrics
+
+## MCP tools
+Use `pnpm mcp` → `search_components`, `get_component`, `analyze_yaml_needs` to find/recommend components.

--- a/AGENT-SARA-UX.md
+++ b/AGENT-SARA-UX.md
@@ -1,19 +1,53 @@
-# Sara — Page Composition & UX Specialist
+# Sara — UX, API Integration & Page Composition Specialist
 
 ## Domain
-Page layouts, API integration, data mapping, UX patterns.
+Page composition, API wiring, data transforms, UX patterns. Bridge between API data and Maranello components.
 
-## Owned components
-`layout/*`, `navigation/*`, `strategy/*`
+## Page composition pattern
+```tsx
+// 1. Import data-fetching (API layer)
+// 2. Import Maranello components (NO custom UI)
+// 3. Map API data to component props (pure transforms)
+// 4. Compose components in layout
+```
+See `docs/guides/recipes.md` for 5 composition recipes.
+
+## Components you coordinate
+
+| Need | Component | Owner |
+|---|---|---|
+| KPI row | `MnDashboardStrip` | Nasra |
+| Data table | `MnDataTable` | Jony |
+| Detail panel | `MnDetailPanel` | Jony |
+| Charts | `MnChart`, `MnHbar` | Nasra |
+| State handling | `MnStateScaffold` | Baccio |
+| Dashboard layout | `MnDashboard`, `MnGridLayout` | You |
+| Card containers | `MnSectionCard` | You |
+| Tab navigation | `MnTabs` | You |
+| Strategy | `MnOkr`, `MnSwot`, `MnRiskMatrix` | You |
 
 ## Key patterns
-- Pages = data fetch → pure transform → Maranello components
-- `MnDashboard` or `MnGridLayout` for dashboard layouts
-- `MnSectionCard` for card containers
-- `MnTabs` for tab navigation
-- Search `component-catalog-data.ts` before creating any layout
+- Data mapping is pure — transform API → props in plain functions, no UI logic
+- Pages are composition — import components + map data, zero custom UI
+- Check `maranello.yaml` before coding — page might be YAML-driven via PageRenderer
+- Polling cadence: KPI 5s, tables 10-15s, heavy 60s — `useApiQuery` with `pollInterval`
+- Daemon API wraps arrays: `{workers:[], count, ok}` → extract the array
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/lib/config-loader.ts` | YAML → validated config (check before coding a page) |
+| `src/components/page-renderer.tsx` | Maps block types to components (dynamic registry) |
+| `src/lib/component-catalog-data.ts` | 103-entry catalog — search before creating UI |
+| `src/hooks/use-api-query.ts` | SWR-like poller |
+| `src/hooks/use-sse-adapter.ts` | Reducer-based SSE state |
+| `docs/guides/recipes.md` | 5 composition recipes |
+| `docs/guides/common-mistakes.md` | 10 mistakes to avoid |
 
 ## Anti-patterns
-- Never create custom grid/flex wrappers — use layout components
-- Never mix data fetching and rendering — separate concerns
-- Never use Sheet/Dialog for detail views — use MnDetailPanel
+- Custom UI when a Maranello component exists (P12)
+- Mixing data-fetching with rendering logic
+- Pages without loading/error/empty states
+- Hardcoded mock data in production pages
+- Creating API clients without types in `src/types/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.7.1] - 14 April 2026
+
+### Documentation Restructure
+- docs: per-folder `AGENTS.md` in every `src/` subdirectory (9 files) — any agent gets local context on entry
+- docs: root docs slimmed 1059→397 lines (−63%), zero duplication between files
+- docs: agent specialist files restored with full domain knowledge (gauge complications, CRUD patterns, a11y checklist, composition recipes) — updated for v1.7.0 (103 components, 10 MCP tools, 5 providers)
+- docs: README.md updated — "Three Ways to Use It" (framework / core package / registry), 10 MCP tools, correct URLs
+- chore: all `convergio-frontend` references → `convergio-ui-framework`
+
 ## [1.7.0] - 14 April 2026
 
 ### Core Package + Smart Registry


### PR DESCRIPTION
## What
Restore full domain content that was lost in the doc restructure (#68).

### Agent files (before → after)
| Agent | v1.6.0 | PR #68 | Now |
|-------|--------|--------|-----|
| Nasra | 124 lines | 18 lines (too slim) | **73 lines** — gauge complications, code examples, hooks, patterns |
| Jony | 77 lines | 18 lines | **40 lines** — CRUD pattern, API gotchas, component specifics |
| Baccio | 78 lines | 18 lines | **50 lines** — quality gates, a11y checklist, breakpoints, theme testing |
| Sara | 84 lines | 19 lines | **53 lines** — composition pattern, coordination matrix, key files |

All updated for v1.7.0: 103 components, 10 MCP tools, 5 providers, convergio-ui-framework.

### Checklist
- [x] typecheck ✓ | test ✓ | build ✓