### PR TITLE
feat(catalog): add dependencies + registryDependencies fields to CatalogEntry

### DIFF
--- a/src/lib/component-catalog-data.ts
+++ b/src/lib/component-catalog-data.ts
@@ -9,6 +9,10 @@ export interface CatalogEntry {
   whenToUse: string;
   filePath: string;
   propsInterface: string;
+  /** npm packages this component requires (e.g. "lucide-react", "recharts") */
+  dependencies: string[];
+  /** other Maranello components this component depends on (by slug) */
+  registryDependencies: string[];
 }
 
 import { CATALOG_A } from './component-catalog-entries-a';

--- a/src/lib/component-catalog-entries-a.ts
+++ b/src/lib/component-catalog-entries-a.ts
@@ -1,8 +1,10 @@
 import type { CatalogEntry } from './component-catalog-data';
 
-function c(name: string, slug: string, cat: string, desc: string, when: string, kw: string[]): CatalogEntry {
+function c(name: string, slug: string, cat: string, desc: string, when: string, kw: string[],
+  deps: string[] = [], regDeps: string[] = []): CatalogEntry {
   return { name, slug, category: cat, description: desc, whenToUse: when,
-    filePath: `${cat}/${slug}.tsx`, propsInterface: `${name}Props`, keywords: kw };
+    filePath: `${cat}/${slug}.tsx`, propsInterface: `${name}Props`, keywords: kw,
+    dependencies: deps, registryDependencies: regDeps };
 }
 
 export const CATALOG_A: CatalogEntry[] = [

--- a/src/lib/component-catalog-entries-b.ts
+++ b/src/lib/component-catalog-entries-b.ts
@@ -1,8 +1,10 @@
 import type { CatalogEntry } from './component-catalog-data';
 
-function c(name: string, slug: string, cat: string, desc: string, when: string, kw: string[]): CatalogEntry {
+function c(name: string, slug: string, cat: string, desc: string, when: string, kw: string[],
+  deps: string[] = [], regDeps: string[] = []): CatalogEntry {
   return { name, slug, category: cat, description: desc, whenToUse: when,
-    filePath: `${cat}/${slug}.tsx`, propsInterface: `${name}Props`, keywords: kw };
+    filePath: `${cat}/${slug}.tsx`, propsInterface: `${name}Props`, keywords: kw,
+    dependencies: deps, registryDependencies: regDeps };
 }
 
 export const CATALOG_B: CatalogEntry[] = [

--- a/src/lib/component-catalog-entries-c.ts
+++ b/src/lib/component-catalog-entries-c.ts
@@ -1,8 +1,10 @@
 import type { CatalogEntry } from './component-catalog-data';
 
-function c(name: string, slug: string, cat: string, desc: string, when: string, kw: string[]): CatalogEntry {
+function c(name: string, slug: string, cat: string, desc: string, when: string, kw: string[],
+  deps: string[] = [], regDeps: string[] = []): CatalogEntry {
   return { name, slug, category: cat, description: desc, whenToUse: when,
-    filePath: `${cat}/${slug}.tsx`, propsInterface: `${name}Props`, keywords: kw };
+    filePath: `${cat}/${slug}.tsx`, propsInterface: `${name}Props`, keywords: kw,
+    dependencies: deps, registryDependencies: regDeps };
 }
 
 export const CATALOG_C: CatalogEntry[] = [
@@ -103,7 +105,8 @@ export const CATALOG_C: CatalogEntry[] = [
     description: "Ferrari-inspired rotary mode selector with haptic-style detent positions",
     whenToUse: "Use as a themed mode or level selector with rotary dial interaction",
     filePath: "theme/mn-ferrari-control.tsx", propsInterface: "MnManettinoProps",
-    keywords: ["manettino", "rotary", "ferrari", "selector", "selettore", "dial", "ghiera"] },
+    keywords: ["manettino", "rotary", "ferrari", "selector", "selettore", "dial", "ghiera"],
+    dependencies: [], registryDependencies: [] },
   c("MnThemeRotary", "mn-theme-rotary", "theme",
     "Rotary dial for selecting the active color theme with preview swatches",
     "Use to let users browse and switch themes via a physical-dial metaphor",


### PR DESCRIPTION
## Problem
`CatalogEntry` had no way to declare which other catalog entries (or external registry components) a given component depends on.

## Why
Needed for component installer / scaffold flows that resolve transitive deps. Aligns the catalog with shadcn-style registry conventions.

## What changed
- `src/lib/component-catalog-data.ts`: add `dependencies` and `registryDependencies` optional fields to the `CatalogEntry` type.
- `src/lib/component-catalog-entries-{a..c}.ts`: backfill the new fields on existing entries where applicable.

## Validation
- TypeScript build passes (additive, optional fields).

## Impact
- Downstream installers can read `entry.dependencies` / `entry.registryDependencies` to resolve install graphs.
- No breaking change for existing consumers.