### PR TITLE
perf(bundle): code-split MnBrain3D to drop three.js from First Load JS

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useApiQuery } from '@/hooks/use-api-query';
 import { useSse } from '@/hooks/use-sse';
@@ -13,8 +14,26 @@ import { MnActivityFeed, type ActivityItem } from '@/components/maranello/feedba
 import {
   MnActiveMissions, type Mission, MnNeuralNodes, type NeuralNodesController,
   MnHubSpoke, type HubSpokeHub, MnAugmentedBrain, MnAugmentedBrainV2,
-  MnBrain3D,
 } from '@/components/maranello/agentic';
+
+// `MnBrain3D` pulls in `three` (~800 KB gz) + `react-force-graph-3d` +
+// `three-spritetext`. Load on demand so the dashboard First Load JS stays
+// lean for visitors who never scroll to the 3D panel.
+const MnBrain3D = dynamic(
+  () =>
+    import('@/components/maranello/agentic').then((m) => ({
+      default: m.MnBrain3D,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        aria-hidden
+        className="h-[500px] w-full rounded-lg border bg-muted/30"
+      />
+    ),
+  },
+);
 import { MnBadge } from '@/components/maranello/data-display';
 import { MnChart } from '@/components/maranello/data-viz';
 import {

--- a/src/app/(dashboard)/showcase/showcase-agentic.tsx
+++ b/src/app/(dashboard)/showcase/showcase-agentic.tsx
@@ -1,16 +1,34 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import {
   MnAugmentedBrain,
   MnAugmentedBrainV2,
   MnBinnacle,
-  MnBrain3D,
   MnChat,
   MnDashboardStrip,
   MnInstrumentBinnacle,
   MnOrgChart,
   MnWorkflowOrchestrator,
 } from '@/components/maranello';
+
+// Lazy `MnBrain3D` to keep `three` + `react-force-graph-3d` out of the
+// agentic-showcase First Load JS.
+const MnBrain3D = dynamic(
+  () =>
+    import('@/components/maranello/agentic').then((m) => ({
+      default: m.MnBrain3D,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        aria-hidden
+        className="h-[500px] w-full rounded-lg border bg-muted/30"
+      />
+    ),
+  },
+);
 import { CATALOG } from '@/lib/component-catalog';
 import { ComponentDoc } from './component-doc';
 import {


### PR DESCRIPTION
## Summary
\`MnBrain3D\` pulls in \`three\` (~800 KB gz) + \`react-force-graph-3d\` + \`three-spritetext\`. Two pages import it statically (dashboard and showcase/agentic), so every visitor pays that cost on initial load regardless of whether they scroll to the 3D panel.

## Fix
Both callsites now use \`next/dynamic\` with \`ssr: false\` and a neutral skeleton, so the 3D engine lands in its own chunk that only streams when the component mounts.

- \`src/app/(dashboard)/dashboard/page.tsx\`
- \`src/app/(dashboard)/showcase/showcase-agentic.tsx\`

The internal lazy \`import()\` inside \`mn-brain-3d.tsx\` / \`.scene.ts\` / \`.geometry.ts\` was already correct — but the outer static re-export from \`@/components/maranello/agentic\` pulled the whole tree into the initial bundle anyway. With \`dynamic()\` the Next compiler generates a proper split point.

## No behaviour change
\`MnBrain3D\` is WebGL-only so \`ssr: false\` is a no-op for correctness — only affects chunk boundaries.

## Verification
- \`pnpm typecheck\` ✓
- \`pnpm lint\` ✓
- \`pnpm test\` 109/109 ✓
- \`pnpm build\` ✓

## Expected impact
Based on the audit: ~180 KB First Load JS savings on \`/dashboard\` and \`/showcase/agentic\`. Exact numbers depend on runtime bundle-analyzer output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)