### PR TITLE
chore(tsconfig): flip skipLibCheck to false

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary
Flips \`\"skipLibCheck\": true\` → \`false\` in \`tsconfig.json\`.

We were silencing every type error that came from dependency \`.d.ts\` files, which kicked the ball down the road: upgrades would break production instead of the next typecheck run.

Current dep set (\`next@16.2.3\`, \`react@19.2.4\`, \`@ai-sdk@^3\`, etc.) produces **zero errors** under \`tsc --noEmit\` with \`skipLibCheck: false\`, so we can tighten the bar with no cleanup work.

## Verification
- \`pnpm typecheck\` — 0 errors
- \`pnpm lint\` — 0 warnings
- \`pnpm test\` — 129 / 129
- \`pnpm build\` — ok

## Why this matters
When we bump Next / React / an AI SDK, this setting will now fail CI on a type mismatch in a dep's types instead of silently letting the app compile against a broken contract. Low-effort, high-signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)