### PR TITLE
feat(api/chat): per-session token-bucket rate limit with real response headers

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -20,3 +20,22 @@ import { MnGauge } from "./components/maranello/data-viz/mn-gauge"; // installed
 ```
 
 This package has zero own code — it re-exports from `../../src/` via tsconfig path aliases.
+
+## Publishing caveat — not standalone yet
+
+> ⚠ **Before running `pnpm publish` from this directory**, you need a build
+> step that copies or bundles the referenced `../../src/` sources into
+> `packages/core/`. The current barrel uses relative paths that resolve
+> inside this monorepo but would 404 from an npm tarball.
+>
+> Minimum viable publish flow (not yet wired):
+>
+> 1. Add a `prepack` / `prepublishOnly` script that runs `tsc --declaration`
+>    against a dedicated `tsconfig.pack.json` rewriting `../../src/*` to
+>    local emitted files, OR use `tsup` / `tsdown` to bundle.
+> 2. Use the `files` field in `package.json` to ship only the generated
+>    output, not the source with relative imports.
+> 3. Exercise the tarball locally with `pnpm pack` + `pnpm add ./*.tgz` in
+>    a throwaway project before releasing.
+>
+> Until that flow exists, treat this package as in-monorepo only.

--- a/src/app/api/chat/route.test.ts
+++ b/src/app/api/chat/route.test.ts
@@ -60,8 +60,12 @@ function chatRequest(body: unknown): Request {
 }
 
 describe("POST /api/chat", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    // Reset the in-memory rate-limit bucket so test-to-test token consumption
+    // does not leak through the shared `"authenticated"` session key.
+    const { __resetBucketsForTests } = await import("@/lib/rate-limit");
+    __resetBucketsForTests();
   });
 
   it("returns 400 for invalid JSON body", async () => {
@@ -135,6 +139,24 @@ describe("POST /api/chat", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("X-RateLimit-Limit")).toBe("60");
     expect(res.headers.get("X-RateLimit-Remaining")).toBe("59");
+  });
+
+  it("returns 429 once the per-session bucket is drained", async () => {
+    const { POST } = await import("./route");
+    const req = () =>
+      chatRequest({ messages: [{ role: "user", content: "hi" }] });
+
+    // 60 requests exhaust the default bucket capacity.
+    for (let i = 0; i < 60; i++) {
+      const r = await POST(req());
+      expect(r.status).toBe(200);
+    }
+    const blocked = await POST(req());
+    expect(blocked.status).toBe(429);
+    const body = await blocked.json();
+    expect(body.error.code).toBe("RATE_LIMITED");
+    expect(blocked.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(Number(blocked.headers.get("Retry-After"))).toBeGreaterThan(0);
   });
 
   it("returns 503 when no agents configured", async () => {

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { openai, createOpenAI } from "@ai-sdk/openai";
 import { streamText } from "ai";
 import { z } from "zod";
+import { consumeToken } from "@/lib/rate-limit";
 import { verifyValue } from "@/lib/session";
 import type { AgentConfig } from "@/types/ai";
 
@@ -88,6 +89,27 @@ export async function POST(req: Request) {
     );
   }
 
+  // Rate limit: 60 chat requests / minute steady state, per session.
+  const rate = consumeToken(sessionValue);
+  if (!rate.allowed) {
+    return Response.json(
+      {
+        error: {
+          code: "RATE_LIMITED",
+          message: "Chat request rate limit exceeded — slow down.",
+        },
+      },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(rate.retryAfterSec),
+          "X-RateLimit-Limit": String(rate.limit),
+          "X-RateLimit-Remaining": "0",
+        },
+      },
+    );
+  }
+
   let body: unknown;
   try {
     body = await req.json();
@@ -140,7 +162,7 @@ export async function POST(req: Request) {
   });
 
   const response = result.toTextStreamResponse();
-  response.headers.set("X-RateLimit-Limit", "60");
-  response.headers.set("X-RateLimit-Remaining", "59");
+  response.headers.set("X-RateLimit-Limit", String(rate.limit));
+  response.headers.set("X-RateLimit-Remaining", String(rate.remaining));
   return response;
 }

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { __resetBucketsForTests, consumeToken } from "./rate-limit";
+
+describe("consumeToken (token bucket)", () => {
+  beforeEach(() => {
+    __resetBucketsForTests();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  it("allows the first request and starts with a full bucket", () => {
+    const r = consumeToken("sess-1", 5, 1);
+    expect(r.allowed).toBe(true);
+    expect(r.limit).toBe(5);
+    expect(r.remaining).toBe(4);
+  });
+
+  it("drains the bucket and rejects the 6th request with a retry-after", () => {
+    for (let i = 0; i < 5; i++) {
+      expect(consumeToken("sess-2", 5, 1).allowed).toBe(true);
+    }
+    const blocked = consumeToken("sess-2", 5, 1);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.remaining).toBe(0);
+    expect(blocked.retryAfterSec).toBeGreaterThan(0);
+  });
+
+  it("refills one token per second up to capacity", () => {
+    for (let i = 0; i < 5; i++) {
+      consumeToken("sess-3", 5, 1);
+    }
+    expect(consumeToken("sess-3", 5, 1).allowed).toBe(false);
+
+    vi.advanceTimersByTime(2_000); // 2 tokens refilled
+
+    expect(consumeToken("sess-3", 5, 1).allowed).toBe(true);
+    expect(consumeToken("sess-3", 5, 1).allowed).toBe(true);
+    expect(consumeToken("sess-3", 5, 1).allowed).toBe(false);
+  });
+
+  it("isolates per-key buckets", () => {
+    for (let i = 0; i < 5; i++) consumeToken("alice", 5, 1);
+    expect(consumeToken("alice", 5, 1).allowed).toBe(false);
+    expect(consumeToken("bob", 5, 1).allowed).toBe(true);
+  });
+
+  it("caps refill at capacity so idle sessions do not accrue extra tokens", () => {
+    consumeToken("sess-4", 3, 1);
+    vi.advanceTimersByTime(10_000); // far more refill than capacity
+    const r = consumeToken("sess-4", 3, 1);
+    expect(r.allowed).toBe(true);
+    expect(r.remaining).toBe(2); // capped at 3 before consume
+  });
+});

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,87 @@
+/**
+ * In-memory token bucket rate limiter.
+ *
+ * Designed for low-ops deployments (single Next.js process, e.g. Vercel
+ * single-region or self-hosted). State is per-process — it resets on
+ * restart and does not replicate across instances. That is acceptable for
+ * the Convergio cockpit, which is a low-concurrency operator tool. When
+ * the framework gains multi-instance deployments, swap the `buckets` map
+ * for an Upstash / Redis-backed store behind the same surface.
+ *
+ * The bucket starts full. Every successful `consumeToken` call removes one
+ * token. Tokens refill at `refillPerSecond` up to `capacity`.
+ */
+
+export interface RateLimitResult {
+  /** Whether the request is allowed to proceed. */
+  allowed: boolean;
+  /** Current token count after this check (pre-consume if allowed). */
+  remaining: number;
+  /** Bucket capacity (used for `X-RateLimit-Limit`). */
+  limit: number;
+  /** Seconds until the next token is available (for `Retry-After`). */
+  retryAfterSec: number;
+}
+
+interface Bucket {
+  tokens: number;
+  updatedAt: number;
+}
+
+const DEFAULT_CAPACITY = 60;
+const DEFAULT_REFILL_PER_SECOND = 1; // 60 requests / minute steady state
+
+const buckets = new Map<string, Bucket>();
+
+function now(): number {
+  return Date.now();
+}
+
+/**
+ * Try to consume one token for `key`.
+ *
+ * @param key — opaque identifier (session id, IP, etc.).
+ * @param capacity — bucket size (default 60).
+ * @param refillPerSecond — refill rate (default 1 tok/s).
+ */
+export function consumeToken(
+  key: string,
+  capacity = DEFAULT_CAPACITY,
+  refillPerSecond = DEFAULT_REFILL_PER_SECOND,
+): RateLimitResult {
+  const t = now();
+  const current = buckets.get(key);
+
+  // Refill.
+  let tokens = capacity;
+  if (current) {
+    const elapsedSec = (t - current.updatedAt) / 1000;
+    tokens = Math.min(capacity, current.tokens + elapsedSec * refillPerSecond);
+  }
+
+  if (tokens < 1) {
+    const needed = 1 - tokens;
+    const retryAfterSec = Math.ceil(needed / refillPerSecond);
+    buckets.set(key, { tokens, updatedAt: t });
+    return {
+      allowed: false,
+      remaining: Math.floor(tokens),
+      limit: capacity,
+      retryAfterSec,
+    };
+  }
+
+  const nextTokens = tokens - 1;
+  buckets.set(key, { tokens: nextTokens, updatedAt: t });
+  return {
+    allowed: true,
+    remaining: Math.floor(nextTokens),
+    limit: capacity,
+    retryAfterSec: 0,
+  };
+}
+
+/** Clear all bucket state. Test-only helper. */
+export function __resetBucketsForTests(): void {
+  buckets.clear();
+}


### PR DESCRIPTION
## Summary
\`POST /api/chat\` used to respond with \`X-RateLimit-Limit: 60\` / \`X-RateLimit-Remaining: 59\` hardcoded on every success — promises with nothing enforcing them. If a signed session cookie leaks or gets stolen, there is no server-side cap on downstream LLM spend.

This PR adds a real in-memory token-bucket rate limit keyed by the verified session value.

## Behaviour
- **Default bucket**: capacity 60, refill 1 token/second — 60 requests / minute steady state, with a 60-request burst.
- **Blocked** (\`rate.allowed === false\`): \`429 RATE_LIMITED\` with \`Retry-After\`, \`X-RateLimit-Limit\`, \`X-RateLimit-Remaining: 0\`.
- **Allowed**: response headers report real remaining tokens, not a stub.
- Every test in \`route.test.ts\` now resets the shared bucket in \`beforeEach\` so the mocked \`authenticated\` session value doesn't leak token consumption across tests.

## Files
- \`src/lib/rate-limit.ts\` — \`consumeToken(key, capacity?, refillPerSecond?)\` + test helper
- \`src/lib/rate-limit.test.ts\` — 5 unit tests (first request, drain, refill, per-key, capacity cap)
- \`src/app/api/chat/route.ts\` — invoke \`consumeToken\` after auth
- \`src/app/api/chat/route.test.ts\` — new 429 case + shared bucket reset

## Deployment trade-off
State is per-process. Fine for single-region Vercel or single self-hosted instance. For horizontally scaled deploys, swap the \`buckets\` Map for an Upstash / Redis store behind the same interface — the callsite in \`route.ts\` does not change.

## Verification
- \`pnpm typecheck\` / \`pnpm lint\` clean
- \`pnpm test\` 135 / 135 (6 new)
- \`pnpm build\` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)