### PR TITLE
chore(mcp): use CONVERGIO_DAEMON_BIN env var instead of hardcoded path

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "convergio": {
-      "command": "/Users/Roberdan/GitHub/convergio/daemon/target/release/convergio-mcp-server",
+      "command": "${CONVERGIO_DAEMON_BIN}",
       "args": ["--transport", "stdio"],
       "env": {
         "CONVERGIO_MCP_RING": "1",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,23 @@ Specialist personas live in [`.claude/agents/`](./.claude/agents/) and can be in
 | `nasra` | Charts, gauges, real-time streaming, dashboards |
 | `sara-ux` | Page composition, API integration, data transforms |
 
+## MCP servers
+
+The repo ships two MCP servers in [.mcp.json](./.mcp.json):
+
+| Name | Purpose | Setup |
+|---|---|---|
+| `maranello-catalog` | Search the 108-entry component catalog (`search_components`, `get_component`, `analyze_yaml_needs`) | Works out of the box — runs `pnpm mcp` |
+| `convergio` | Talks to the Convergio daemon | Requires `CONVERGIO_DAEMON_BIN` env var pointing at the compiled `convergio-mcp-server` binary |
+
+For the `convergio` entry, add this to your shell rc once per machine:
+
+```bash
+export CONVERGIO_DAEMON_BIN="$HOME/GitHub/convergio/daemon/target/release/convergio-mcp-server"
+```
+
+Adjust the path if the daemon repo lives elsewhere. If the variable is unset, Claude Code will skip the server with a startup warning — the rest of the framework keeps working.
+
 ## Build commands
 
 ```bash


### PR DESCRIPTION
## Summary

The `convergio` MCP server in `.mcp.json` was hardcoded to `/Users/Roberdan/GitHub/convergio/daemon/...` — works on Roberdan's machine, breaks the repo for everyone else on first clone. This switches to `${CONVERGIO_DAEMON_BIN}` env-var expansion (a feature `.mcp.json` already supports) so each environment configures its own path once in the shell rc.

The companion `maranello-catalog` server is unaffected — it uses `pnpm mcp` and is fully portable.

## Setup (documented in AGENTS.md)

```bash
export CONVERGIO_DAEMON_BIN="$HOME/GitHub/convergio/daemon/target/release/convergio-mcp-server"
```

If the variable is unset, Claude Code logs a startup warning for the `convergio` entry and continues — the framework keeps working.

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test` — 135/135 pass
- [x] `pnpm build` — OK (36 routes)
- [x] `npx tsx scripts/verify-counts.ts` — clean
- [ ] Reviewer: confirm `.mcp.json` no longer contains `/Users/Roberdan`
- [ ] Reviewer: try opening the repo on a fresh machine with the export set — `convergio` MCP starts; without the export — only `maranello-catalog` starts and nothing else regresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)